### PR TITLE
Реализовать графический выбор области захвата

### DIFF
--- a/gui/controllers/settings_controller.py
+++ b/gui/controllers/settings_controller.py
@@ -7,7 +7,7 @@
 """
 
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from config import ConfigManager, get_config
 from gui.models.recording_state import (
@@ -63,6 +63,28 @@ class SettingsController:
         self._state.video.bitrate = settings.video.bitrate
         self._state.video.format = settings.video.format
 
+        capture_type_map = {
+            "full": CaptureType.FULL,
+            "window": CaptureType.WINDOW,
+            "rect": CaptureType.RECT,
+        }
+        self._state.capture.capture_type = capture_type_map.get(
+            settings.capture.area_type,
+            CaptureType.FULL,
+        )
+        self._state.capture.window_title = settings.capture.window_title or ""
+        if (
+            settings.capture.rect_coords
+            and len(settings.capture.rect_coords) == 4
+        ):
+            x1, y1, x2, y2 = settings.capture.rect_coords
+            self._state.capture.rect_coords = (
+                int(x1),
+                int(y1),
+                int(x2),
+                int(y2),
+            )
+
         # Путь вывода
         if settings.output.default_path:
             self._state.output.default_path = settings.output.default_path
@@ -92,6 +114,17 @@ class SettingsController:
         settings.video.codec = self._state.video.codec
         settings.video.bitrate = self._state.video.bitrate
         settings.video.format = self._state.video.format
+
+        settings.capture.area_type = self._state.capture.capture_type.value
+        settings.capture.window_title = (
+            self._state.capture.window_title or None
+        )
+        if self._state.capture.capture_type == CaptureType.RECT:
+            settings.capture.rect_coords = list(
+                self._state.capture.rect_coords
+            )
+        else:
+            settings.capture.rect_coords = None
 
         # Путь вывода
         if self._state.output.default_path:
@@ -207,17 +240,21 @@ class SettingsController:
         Returns:
             Путь к выходному файлу
         """
-        filename = cast(str, self._state.get_output_filename())
+        filename = self._state.get_output_filename()
         if self._state.output.output_path:
             output_path = Path(self._state.output.output_path)
             if output_path.exists() and output_path.is_dir():
-                return output_path / filename
+                return Path(output_path, filename)
             if output_path.suffix == "":
-                return output_path.with_suffix(f".{self._state.video.format}")
-            return output_path
+                return Path(
+                    str(
+                        output_path.with_suffix(f".{self._state.video.format}")
+                    )
+                )
+            return Path(str(output_path))
 
         # Генерация пути по умолчанию
         default_path = self._state.output.default_path
         if default_path:
-            return Path(default_path) / filename
+            return Path(default_path, filename)
         return Path(filename)

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -342,6 +342,11 @@ class MainWindow(QMainWindow):
 
     def _apply_settings_to_views(self) -> None:
         """Применение настроек к представлениям."""
+        self._capture_view.set_capture_type(self._state.capture.capture_type)
+        self._capture_view.set_window_title(self._state.capture.window_title)
+        if self._state.capture.capture_type == CaptureMode.RECT:
+            self._capture_view.set_rect_coords(self._state.capture.rect_coords)
+
         # Настройки видео
         self._video_view.set_settings(self._state.video)
 

--- a/gui/scheduler_tab.py
+++ b/gui/scheduler_tab.py
@@ -6,7 +6,7 @@
 """
 
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 from PyQt6.QtCore import QDate, Qt, QTime, pyqtSignal
 from PyQt6.QtWidgets import (
@@ -592,7 +592,7 @@ class SchedulerTab(QWidget):
         """Форматирование расписания для отображения."""
         if task.schedule_type == ScheduleType.ONCE:
             if task.start_time:
-                return task.start_time.strftime("%Y-%m-%d %H:%M")
+                return cast(str, task.start_time.strftime("%Y-%m-%d %H:%M"))
         elif task.schedule_type == ScheduleType.DAILY:
             return f"Ежедневно в {task.time_of_day}"
         elif task.schedule_type == ScheduleType.WEEKLY:

--- a/gui/scheduler_tab.py
+++ b/gui/scheduler_tab.py
@@ -6,7 +6,7 @@
 """
 
 from datetime import datetime
-from typing import Any, cast
+from typing import Any
 
 from PyQt6.QtCore import QDate, Qt, QTime, pyqtSignal
 from PyQt6.QtWidgets import (
@@ -592,7 +592,7 @@ class SchedulerTab(QWidget):
         """Форматирование расписания для отображения."""
         if task.schedule_type == ScheduleType.ONCE:
             if task.start_time:
-                return cast(str, task.start_time.strftime("%Y-%m-%d %H:%M"))
+                return task.start_time.strftime("%Y-%m-%d %H:%M")
         elif task.schedule_type == ScheduleType.DAILY:
             return f"Ежедневно в {task.time_of_day}"
         elif task.schedule_type == ScheduleType.WEEKLY:

--- a/gui/views/area_selector.py
+++ b/gui/views/area_selector.py
@@ -1,0 +1,589 @@
+"""
+Графический выбор и предпросмотр области захвата.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor, QGuiApplication, QPainter, QPen
+from PyQt6.QtWidgets import QDialog, QWidget
+
+from logger_config import get_module_logger
+
+logger = get_module_logger(__name__)
+
+RectCoords = tuple[int, int, int, int]
+PointCoords = tuple[int, int]
+
+MIN_SELECTION_SIZE = 8
+RESIZE_HANDLE_SIZE = 12
+PREVIEW_MARGIN = 10
+
+
+def normalize_rect_coords(start: PointCoords, end: PointCoords) -> RectCoords:
+    """
+    Нормализовать координаты прямоугольника.
+
+    Args:
+        start: Первая точка.
+        end: Вторая точка.
+
+    Returns:
+        Кортеж координат `(x1, y1, x2, y2)` с упорядоченными углами.
+    """
+    x1, y1 = start
+    x2, y2 = end
+    return (
+        min(x1, x2),
+        min(y1, y2),
+        max(x1, x2),
+        max(y1, y2),
+    )
+
+
+def rect_size(rect: RectCoords) -> tuple[int, int]:
+    """
+    Получить размер прямоугольника.
+
+    Args:
+        rect: Координаты прямоугольника.
+
+    Returns:
+        Ширина и высота.
+    """
+    return rect[2] - rect[0], rect[3] - rect[1]
+
+
+def format_rect_coords(rect: RectCoords | None) -> str:
+    """
+    Сформировать строку с координатами области.
+
+    Args:
+        rect: Координаты прямоугольника.
+
+    Returns:
+        Строка для отображения в UI.
+    """
+    if rect is None:
+        return ""
+    return f"{rect[0]}, {rect[1]}, {rect[2]}, {rect[3]}"
+
+
+def describe_rect(rect: RectCoords | None) -> str:
+    """
+    Сформировать краткое описание выбранной области.
+
+    Args:
+        rect: Координаты прямоугольника.
+
+    Returns:
+        Человекочитаемая сводка.
+    """
+    if rect is None:
+        return "Область не выбрана"
+
+    width, height = rect_size(rect)
+    return f"Позиция: {rect[0]}, {rect[1]} · Размер: {width} × {height} px"
+
+
+def point_in_rect(point: PointCoords, rect: RectCoords) -> bool:
+    """
+    Проверить, находится ли точка внутри прямоугольника.
+
+    Args:
+        point: Проверяемая точка.
+        rect: Координаты прямоугольника.
+
+    Returns:
+        `True`, если точка лежит внутри прямоугольника.
+    """
+    x, y = point
+    return rect[0] <= x <= rect[2] and rect[1] <= y <= rect[3]
+
+
+def point_in_resize_handle(
+    point: PointCoords,
+    rect: RectCoords,
+    handle_size: int = RESIZE_HANDLE_SIZE,
+) -> bool:
+    """
+    Проверить попадание в маркер изменения размера.
+
+    Args:
+        point: Проверяемая точка.
+        rect: Координаты прямоугольника.
+        handle_size: Размер зоны маркера.
+
+    Returns:
+        `True`, если точка попала в правый нижний маркер.
+    """
+    x, y = point
+    return (
+        rect[2] - handle_size <= x <= rect[2] + handle_size
+        and rect[3] - handle_size <= y <= rect[3] + handle_size
+    )
+
+
+def clamp_rect_to_bounds(
+    rect: RectCoords,
+    bounds: RectCoords,
+) -> RectCoords:
+    """
+    Ограничить прямоугольник границами экрана.
+
+    Args:
+        rect: Координаты прямоугольника.
+        bounds: Границы рабочей области.
+
+    Returns:
+        Прямоугольник, целиком помещающийся в границы.
+    """
+    left, top, right, bottom = rect
+    min_x, min_y, max_x, max_y = bounds
+
+    left = max(min_x, min(left, max_x))
+    right = max(min_x, min(right, max_x))
+    top = max(min_y, min(top, max_y))
+    bottom = max(min_y, min(bottom, max_y))
+    return normalize_rect_coords((left, top), (right, bottom))
+
+
+def move_rect(
+    rect: RectCoords,
+    top_left: PointCoords,
+    bounds: RectCoords,
+) -> RectCoords:
+    """
+    Переместить прямоугольник, не выходя за границы экрана.
+
+    Args:
+        rect: Исходный прямоугольник.
+        top_left: Новая верхняя левая точка.
+        bounds: Границы экрана.
+
+    Returns:
+        Перемещённый прямоугольник.
+    """
+    width, height = rect_size(rect)
+    min_x, min_y, max_x, max_y = bounds
+
+    max_left = max(min_x, max_x - width)
+    max_top = max(min_y, max_y - height)
+    left = max(min_x, min(top_left[0], max_left))
+    top = max(min_y, min(top_left[1], max_top))
+    return (left, top, left + width, top + height)
+
+
+def resize_rect(
+    anchor: PointCoords,
+    point: PointCoords,
+    bounds: RectCoords,
+) -> RectCoords:
+    """
+    Изменить размер прямоугольника от фиксированной опорной точки.
+
+    Args:
+        anchor: Зафиксированная точка прямоугольника.
+        point: Новая точка перетаскивания.
+        bounds: Границы экрана.
+
+    Returns:
+        Нормализованный и ограниченный прямоугольник.
+    """
+    return clamp_rect_to_bounds(
+        normalize_rect_coords(anchor, point),
+        bounds,
+    )
+
+
+def is_valid_selection(rect: RectCoords | None) -> bool:
+    """
+    Проверить, достаточно ли велика выбранная область.
+
+    Args:
+        rect: Координаты прямоугольника.
+
+    Returns:
+        `True`, если прямоугольник пригоден для использования.
+    """
+    if rect is None:
+        return False
+    width, height = rect_size(rect)
+    return width >= MIN_SELECTION_SIZE and height >= MIN_SELECTION_SIZE
+
+
+@dataclass(frozen=True)
+class ScreenSize:
+    """Размер экрана для превью."""
+
+    width: int
+    height: int
+
+
+class SelectionPreviewWidget(QWidget):
+    """
+    Компактный виджет предпросмотра выбранной области.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """
+        Инициализировать виджет предпросмотра.
+
+        Args:
+            parent: Родительский виджет.
+        """
+        super().__init__(parent)
+        self._screen = ScreenSize(width=1920, height=1080)
+        self._rect_coords: RectCoords | None = None
+        self.setMinimumHeight(96)
+
+    def set_screen_size(self, width: int, height: int) -> None:
+        """
+        Обновить размер экрана, относительно которого строится превью.
+
+        Args:
+            width: Ширина экрана.
+            height: Высота экрана.
+        """
+        self._screen = ScreenSize(
+            width=max(width, 1),
+            height=max(height, 1),
+        )
+        if hasattr(self, "update"):
+            self.update()
+
+    def set_rect_coords(self, coords: RectCoords | None) -> None:
+        """
+        Обновить выбранный прямоугольник.
+
+        Args:
+            coords: Координаты выбранной области.
+        """
+        self._rect_coords = coords
+        if hasattr(self, "update"):
+            self.update()
+
+    def paintEvent(self, _event) -> None:  # noqa: N802
+        """Отрисовать мини-превью прямоугольной области."""
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+
+        width = max(self.width(), 1)
+        height = max(self.height(), 1)
+        available_width = max(width - PREVIEW_MARGIN * 2, 1)
+        available_height = max(height - PREVIEW_MARGIN * 2, 1)
+        scale = min(
+            available_width / self._screen.width,
+            available_height / self._screen.height,
+        )
+
+        preview_width = int(self._screen.width * scale)
+        preview_height = int(self._screen.height * scale)
+        left = (width - preview_width) // 2
+        top = (height - preview_height) // 2
+
+        painter.setPen(QPen(QColor("#6b7280"), 1))
+        painter.setBrush(QColor("#111827"))
+        painter.drawRect(left, top, preview_width, preview_height)
+
+        if self._rect_coords is None:
+            painter.setPen(QColor("#9ca3af"))
+            painter.drawText(
+                left + 12,
+                top + preview_height // 2,
+                "Область пока не выбрана",
+            )
+            return
+
+        rect_left = left + int(self._rect_coords[0] * scale)
+        rect_top = top + int(self._rect_coords[1] * scale)
+        rect_width = int((self._rect_coords[2] - self._rect_coords[0]) * scale)
+        rect_height = int(
+            (self._rect_coords[3] - self._rect_coords[1]) * scale
+        )
+
+        painter.setPen(QPen(QColor("#ef4444"), 2))
+        painter.setBrush(QColor(239, 68, 68, 60))
+        painter.drawRect(rect_left, rect_top, rect_width, rect_height)
+
+
+class AreaSelectorDialog(QDialog):
+    """
+    Полноэкранный overlay для выбора прямоугольной области мышью.
+    """
+
+    selection_completed = pyqtSignal(tuple)
+
+    def __init__(
+        self,
+        initial_rect: RectCoords | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        """
+        Инициализировать overlay выбора области.
+
+        Args:
+            initial_rect: Исходная выбранная область.
+            parent: Родительский виджет.
+        """
+        super().__init__(parent)
+        self._selection: RectCoords | None = initial_rect
+        self._bounds = self._get_screen_bounds()
+        self._drag_mode: str | None = None
+        self._drag_origin: PointCoords | None = None
+        self._move_offset: PointCoords = (0, 0)
+        self._resize_anchor: PointCoords | None = None
+
+        self._setup_window()
+
+    @classmethod
+    def select_area(
+        cls,
+        parent: QWidget | None = None,
+        initial_rect: RectCoords | None = None,
+    ) -> RectCoords | None:
+        """
+        Открыть overlay и вернуть выбранную область.
+
+        Args:
+            parent: Родительский виджет.
+            initial_rect: Текущая область для повторного редактирования.
+
+        Returns:
+            Выбранные координаты или `None`, если пользователь отменил выбор.
+        """
+        selector = cls(initial_rect=initial_rect, parent=parent)
+        result = selector.exec()
+        dialog_code = getattr(QDialog, "DialogCode", None)
+        if dialog_code is not None:
+            return (
+                selector.get_selected_rect()
+                if result == QDialog.DialogCode.Accepted
+                else None
+            )
+        return selector.get_selected_rect() if result else None
+
+    def _setup_window(self) -> None:
+        """Настроить свойства overlay-окна."""
+        self.setWindowTitle("Выбор области захвата")
+        self.setWindowFlags(
+            Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.Tool
+        )
+        self.setModal(True)
+        self.setCursor(Qt.CursorShape.CrossCursor)
+
+        if hasattr(Qt, "WidgetAttribute") and hasattr(
+            Qt.WidgetAttribute,
+            "WA_TranslucentBackground",
+        ):
+            self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+
+        left, top, right, bottom = self._bounds
+        self.setGeometry(left, top, right - left, bottom - top)
+
+    def _get_screen_bounds(self) -> RectCoords:
+        """
+        Получить геометрию основного экрана.
+
+        Returns:
+            Координаты границ экрана.
+        """
+        app = QGuiApplication.instance()
+        if app is None:
+            app = QGuiApplication([])
+
+        screen = QGuiApplication.primaryScreen()
+        if screen is None:
+            logger.warning(
+                "Не удалось получить primaryScreen, используется fallback"
+            )
+            return (0, 0, 1920, 1080)
+
+        geometry = screen.geometry()
+        return (
+            geometry.left(),
+            geometry.top(),
+            geometry.right(),
+            geometry.bottom(),
+        )
+
+    def get_selected_rect(self) -> RectCoords | None:
+        """
+        Получить текущую выбранную область.
+
+        Returns:
+            Координаты прямоугольника или `None`.
+        """
+        if is_valid_selection(self._selection):
+            return self._selection
+        return None
+
+    def _event_point(self, event) -> PointCoords:
+        """
+        Извлечь координаты точки из Qt-события.
+
+        Args:
+            event: Qt mouse event.
+
+        Returns:
+            Пара координат.
+        """
+        position = getattr(event, "position", None)
+        if callable(position):
+            point = position()
+            return int(point.x()), int(point.y())
+
+        point = event.pos()
+        return int(point.x()), int(point.y())
+
+    def mousePressEvent(self, event) -> None:  # noqa: N802
+        """Начать создание, перемещение или изменение размера области."""
+        if event.button() != Qt.MouseButton.LeftButton:
+            return
+
+        point = self._event_point(event)
+        selection = self.get_selected_rect()
+
+        if selection is not None and point_in_resize_handle(point, selection):
+            self._drag_mode = "resize"
+            self._resize_anchor = (selection[0], selection[1])
+            return
+
+        if selection is not None and point_in_rect(point, selection):
+            self._drag_mode = "move"
+            self._move_offset = (
+                point[0] - selection[0],
+                point[1] - selection[1],
+            )
+            return
+
+        self._drag_mode = "new"
+        self._drag_origin = point
+        self._selection = normalize_rect_coords(point, point)
+        if hasattr(self, "update"):
+            self.update()
+
+    def mouseMoveEvent(self, event) -> None:  # noqa: N802
+        """Обновить текущую область по движению мыши."""
+        if self._drag_mode is None:
+            return
+
+        point = self._event_point(event)
+
+        if self._drag_mode == "new" and self._drag_origin is not None:
+            self._selection = resize_rect(
+                self._drag_origin,
+                point,
+                self._bounds,
+            )
+        elif self._drag_mode == "resize" and self._resize_anchor is not None:
+            self._selection = resize_rect(
+                self._resize_anchor,
+                point,
+                self._bounds,
+            )
+        elif self._drag_mode == "move" and self._selection is not None:
+            self._selection = move_rect(
+                self._selection,
+                (
+                    point[0] - self._move_offset[0],
+                    point[1] - self._move_offset[1],
+                ),
+                self._bounds,
+            )
+
+        if hasattr(self, "update"):
+            self.update()
+
+    def mouseReleaseEvent(self, event) -> None:  # noqa: N802
+        """Завершить текущее действие мышью."""
+        if event.button() != Qt.MouseButton.LeftButton:
+            return
+
+        if not is_valid_selection(self._selection):
+            self._selection = None
+
+        self._drag_mode = None
+        self._drag_origin = None
+        self._resize_anchor = None
+
+        if hasattr(self, "update"):
+            self.update()
+
+    def mouseDoubleClickEvent(self, event) -> None:  # noqa: N802
+        """Подтвердить выбор двойным кликом внутри области."""
+        selection = self.get_selected_rect()
+        if selection is None:
+            return
+
+        if point_in_rect(self._event_point(event), selection):
+            self.selection_completed.emit(selection)
+            self.accept()
+
+    def keyPressEvent(self, event) -> None:  # noqa: N802
+        """Обработать горячие клавиши overlay."""
+        key = event.key()
+        if key == Qt.Key.Key_Escape:
+            self.reject()
+            return
+
+        if key in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            selection = self.get_selected_rect()
+            if selection is not None:
+                self.selection_completed.emit(selection)
+                self.accept()
+            return
+
+        super().keyPressEvent(event)
+
+    def paintEvent(self, _event) -> None:  # noqa: N802
+        """Отрисовать затемнение, рамку выделения и подсказку."""
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.fillRect(self.rect(), QColor(0, 0, 0, 90))
+
+        painter.setPen(QPen(QColor("#ffffff"), 1))
+        painter.drawText(
+            24,
+            36,
+            (
+                "Потяните мышью для выбора области. "
+                "Перетащите внутри рамки для перемещения, "
+                "тяните правый нижний маркер для изменения размера, "
+                "Enter — подтвердить, Esc — отменить."
+            ),
+        )
+
+        selection = self.get_selected_rect()
+        if selection is None:
+            return
+
+        width, height = rect_size(selection)
+
+        painter.setPen(QPen(QColor("#ef4444"), 2))
+        painter.setBrush(QColor(239, 68, 68, 45))
+        painter.drawRect(
+            selection[0],
+            selection[1],
+            width,
+            height,
+        )
+
+        painter.setBrush(QColor("#ef4444"))
+        painter.drawRect(
+            selection[2] - 5,
+            selection[3] - 5,
+            10,
+            10,
+        )
+
+        painter.setPen(QColor("#ffffff"))
+        painter.drawText(
+            selection[0],
+            max(selection[1] - 10, 20),
+            f"{width} × {height} px",
+        )

--- a/gui/views/capture_view.py
+++ b/gui/views/capture_view.py
@@ -1,8 +1,5 @@
 """
-Представление области захвата
-=============================
-
-Компонент UI для выбора области захвата экрана.
+Представление области захвата.
 """
 
 from PyQt6.QtCore import pyqtSignal
@@ -11,7 +8,6 @@ from PyQt6.QtWidgets import (
     QComboBox,
     QGroupBox,
     QHBoxLayout,
-    QInputDialog,
     QLabel,
     QLineEdit,
     QPushButton,
@@ -21,10 +17,13 @@ from PyQt6.QtWidgets import (
 )
 
 from gui.models.recording_state import CaptureType
-from logger_config import get_module_logger
+from gui.views.area_selector import (
+    AreaSelectorDialog,
+    SelectionPreviewWidget,
+    describe_rect,
+    format_rect_coords,
+)
 from recorder.utils import get_available_windows, get_screen_size
-
-logger = get_module_logger(__name__)
 
 
 class CaptureView(QWidget):
@@ -32,24 +31,25 @@ class CaptureView(QWidget):
     Представление для выбора области захвата.
 
     Содержит:
-    - Радиокнопки для выбора типа области
-    - Селектор окон
-    - Поле ввода координат прямоугольника
+    - Радиокнопки для выбора типа области.
+    - Селектор окон.
+    - Графический выбор прямоугольной области.
     """
 
-    # Сигналы
     capture_type_changed = pyqtSignal(CaptureType)
     window_selected = pyqtSignal(str)
-    rect_selected = pyqtSignal(tuple)  # (x1, y1, x2, y2)
+    rect_selected = pyqtSignal(tuple)
 
     def __init__(self, parent: QWidget | None = None):
         """
         Инициализация представления.
 
         Args:
-            parent: Родительский виджет
+            parent: Родительский виджет.
         """
         super().__init__(parent)
+        self._rect_coords: tuple[int, int, int, int] | None = None
+        self._screen_size = get_screen_size()
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -60,7 +60,6 @@ class CaptureView(QWidget):
         group = QGroupBox("Область захвата")
         group_layout = QVBoxLayout(group)
 
-        # Радиокнопки
         self._button_group = QButtonGroup()
 
         self._full_screen_radio = QRadioButton("Весь экран")
@@ -72,7 +71,6 @@ class CaptureView(QWidget):
         self._button_group.addButton(self._window_radio, 1)
         group_layout.addWidget(self._window_radio)
 
-        # Селектор окон
         window_layout = QHBoxLayout()
         self._window_combo = QComboBox()
         self._window_combo.setMinimumWidth(200)
@@ -91,28 +89,33 @@ class CaptureView(QWidget):
         self._button_group.addButton(self._rect_radio, 2)
         group_layout.addWidget(self._rect_radio)
 
-        # Координаты прямоугольника
         rect_layout = QHBoxLayout()
         self._rect_edit = QLineEdit()
-        self._rect_edit.setPlaceholderText("X1, Y1, X2, Y2")
+        self._rect_edit.setPlaceholderText("Область не выбрана")
+        self._rect_edit.setReadOnly(True)
         self._rect_edit.setEnabled(False)
 
-        select_rect_btn = QPushButton("Выбрать")
-        select_rect_btn.setMaximumWidth(80)
-        select_rect_btn.clicked.connect(self._select_rectangle)
+        self._select_rect_btn = QPushButton("Выбрать")
+        self._select_rect_btn.setMaximumWidth(90)
+        self._select_rect_btn.clicked.connect(self._select_rectangle)
 
-        rect_layout.addWidget(QLabel("Координаты:"))
+        rect_layout.addWidget(QLabel("Область:"))
         rect_layout.addWidget(self._rect_edit)
-        rect_layout.addWidget(select_rect_btn)
+        rect_layout.addWidget(self._select_rect_btn)
         group_layout.addLayout(rect_layout)
 
-        # Подключение сигналов
+        self._rect_summary_label = QLabel()
+        self._rect_summary_label.setText("Область не выбрана")
+        group_layout.addWidget(self._rect_summary_label)
+
+        self._rect_preview = SelectionPreviewWidget()
+        self._rect_preview.set_screen_size(*self._screen_size)
+        group_layout.addWidget(self._rect_preview)
+
         self._button_group.buttonClicked.connect(self._on_button_clicked)
         self._window_combo.currentTextChanged.connect(self._on_window_changed)
 
-        # Начальное состояние
         self._update_enabled_state()
-
         layout.addWidget(group)
 
     def _refresh_windows(self) -> None:
@@ -124,27 +127,22 @@ class CaptureView(QWidget):
             self._window_combo.addItem(win["title"])
 
     def _select_rectangle(self) -> None:
-        """Открытие диалога для выбора прямоугольника."""
-        screen_width, screen_height = get_screen_size()
-
-        text, ok = QInputDialog.getText(
+        """Открыть overlay для графического выбора области."""
+        coords = AreaSelectorDialog.select_area(
             self,
-            "Выбор области",
-            "Введите координаты (x1, y1, x2, y2):",
-            QLineEdit.EchoMode.Normal,
-            f"0, 0, {screen_width}, {screen_height}",
+            initial_rect=self._rect_coords,
         )
 
-        if ok:
-            self._rect_edit.setText(text)
-            self._rect_radio.setChecked(True)
+        if coords is not None:
+            self.set_rect_coords(coords)
+            self.set_capture_type(CaptureType.RECT)
             self._on_button_clicked(self._rect_radio)
+            self.rect_selected.emit(coords)
 
     def _on_button_clicked(self, button: QRadioButton) -> None:
         """Обработка клика по радиокнопке."""
         self._update_enabled_state()
 
-        # Определение типа захвата
         if button == self._full_screen_radio:
             capture_type = CaptureType.FULL
         elif button == self._window_radio:
@@ -165,27 +163,28 @@ class CaptureView(QWidget):
 
         self._window_combo.setEnabled(is_window)
         self._rect_edit.setEnabled(is_rect)
+        self._rect_summary_label.setEnabled(is_rect)
+        self._rect_preview.setEnabled(is_rect)
 
     def get_capture_type(self) -> CaptureType:
         """
         Получить выбранный тип области захвата.
 
         Returns:
-            Тип области захвата
+            Тип области захвата.
         """
-        if self._full_screen_radio.isChecked():
-            return CaptureType.FULL
-        elif self._window_radio.isChecked():
-            return CaptureType.WINDOW
-        else:
+        if self._rect_radio.isChecked():
             return CaptureType.RECT
+        if self._window_radio.isChecked():
+            return CaptureType.WINDOW
+        return CaptureType.FULL
 
     def get_window_title(self) -> str:
         """
         Получить выбранный заголовок окна.
 
         Returns:
-            Заголовок окна
+            Заголовок окна.
         """
         return self._window_combo.currentText()
 
@@ -194,24 +193,20 @@ class CaptureView(QWidget):
         Получить координаты прямоугольника.
 
         Returns:
-            Кортеж (x1, y1, x2, y2) или None при ошибке
+            Кортеж `(x1, y1, x2, y2)` или `None`.
         """
-        coords_text = self._rect_edit.text()
-        try:
-            coords = [int(x.strip()) for x in coords_text.split(",")]
-            if len(coords) == 4:
-                return (coords[0], coords[1], coords[2], coords[3])
-        except ValueError:
-            pass
-        return None
+        return self._rect_coords
 
     def set_capture_type(self, capture_type: CaptureType) -> None:
         """
         Установить тип области захвата.
 
         Args:
-            capture_type: Тип области захвата
+            capture_type: Тип области захвата.
         """
+        self._full_screen_radio.setChecked(False)
+        self._window_radio.setChecked(False)
+        self._rect_radio.setChecked(False)
         if capture_type == CaptureType.FULL:
             self._full_screen_radio.setChecked(True)
         elif capture_type == CaptureType.WINDOW:
@@ -225,9 +220,16 @@ class CaptureView(QWidget):
         Установить выбранный заголовок окна.
 
         Args:
-            title: Заголовок окна
+            title: Заголовок окна.
         """
-        index = self._window_combo.findText(title)
+        if hasattr(self._window_combo, "findText"):
+            index = self._window_combo.findText(title)
+        else:
+            index = -1
+            for current_index in range(self._window_combo.count()):
+                if self._window_combo.itemText(current_index) == title:
+                    index = current_index
+                    break
         if index >= 0:
             self._window_combo.setCurrentIndex(index)
 
@@ -236,8 +238,9 @@ class CaptureView(QWidget):
         Установить координаты прямоугольника.
 
         Args:
-            coords: Кортеж (x1, y1, x2, y2)
+            coords: Кортеж `(x1, y1, x2, y2)`.
         """
-        self._rect_edit.setText(
-            f"{coords[0]}, {coords[1]}, {coords[2]}, {coords[3]}"
-        )
+        self._rect_coords = coords
+        self._rect_edit.setText(format_rect_coords(coords))
+        self._rect_summary_label.setText(describe_rect(coords))
+        self._rect_preview.set_rect_coords(coords)

--- a/tests/unit/test_capture_area_selector.py
+++ b/tests/unit/test_capture_area_selector.py
@@ -2,6 +2,7 @@
 Тесты графического выбора области захвата.
 """
 
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -9,10 +10,14 @@ from config import ConfigManager
 from gui.controllers.settings_controller import SettingsController
 from gui.models.recording_state import CaptureType, RecordingState
 from gui.views.area_selector import (
+    AreaSelectorDialog,
     describe_rect,
     format_rect_coords,
+    is_valid_selection,
     move_rect,
     normalize_rect_coords,
+    point_in_rect,
+    point_in_resize_handle,
     resize_rect,
 )
 from gui.views.capture_view import CaptureView
@@ -48,6 +53,179 @@ class TestAreaSelectorHelpers:
     def test_format_rect_coords(self) -> None:
         """Координаты форматируются в строку для GUI."""
         assert format_rect_coords((1, 2, 3, 4)) == "1, 2, 3, 4"
+
+    def test_point_in_rect(self) -> None:
+        """Точка внутри области определяется корректно."""
+        assert point_in_rect((50, 60), (10, 20, 100, 120))
+
+    def test_point_in_resize_handle(self) -> None:
+        """Правый нижний маркер resize распознаётся по координатам."""
+        assert point_in_resize_handle((100, 120), (10, 20, 100, 120))
+
+    def test_is_valid_selection(self) -> None:
+        """Слишком маленькая область считается невалидной."""
+        assert not is_valid_selection((0, 0, 3, 3))
+        assert is_valid_selection((0, 0, 10, 10))
+
+
+class _FakeMouseEvent:
+    """Упрощённое mouse event для тестов selector-а."""
+
+    def __init__(
+        self,
+        x: int,
+        y: int,
+        button: object,
+        use_position: bool = False,
+    ) -> None:
+        self._x = x
+        self._y = y
+        self._button = button
+        if use_position:
+            self.position = lambda: SimpleNamespace(  # noqa: B023
+                x=lambda: self._x,
+                y=lambda: self._y,
+            )
+
+    def button(self) -> object:
+        """Вернуть кнопку мыши."""
+        return self._button
+
+    def pos(self) -> SimpleNamespace:
+        """Вернуть координаты через совместимый pos()."""
+        return SimpleNamespace(x=lambda: self._x, y=lambda: self._y)
+
+
+class _FakeKeyEvent:
+    """Упрощённое key event для тестов selector-а."""
+
+    def __init__(self, key: object) -> None:
+        self._key = key
+
+    def key(self) -> object:
+        """Вернуть код клавиши."""
+        return self._key
+
+
+class TestAreaSelectorDialog:
+    """Тесты поведения диалога выбора области."""
+
+    def _create_dialog(self) -> AreaSelectorDialog:
+        """Создать selector с безопасно замоканным окном."""
+        with (
+            patch.object(
+                AreaSelectorDialog,
+                "_get_screen_bounds",
+                return_value=(0, 0, 1920, 1080),
+            ),
+            patch.object(AreaSelectorDialog, "_setup_window"),
+        ):
+            dialog = AreaSelectorDialog()
+        dialog.update = MagicMock()
+        dialog.accept = MagicMock()
+        dialog.reject = MagicMock()
+        dialog.selection_completed = MagicMock()
+        return dialog
+
+    def test_select_area_returns_selection_for_accepted_dialog(self) -> None:
+        """select_area возвращает выбранный rect после успешного confirm."""
+
+        def fake_init(
+            self,
+            initial_rect=None,
+            parent=None,
+        ) -> None:
+            self._selection = initial_rect
+
+        with (
+            patch.object(AreaSelectorDialog, "__init__", fake_init),
+            patch.object(
+                AreaSelectorDialog, "exec", return_value=1, create=True
+            ),
+            patch.object(
+                AreaSelectorDialog,
+                "get_selected_rect",
+                return_value=(10, 20, 100, 200),
+            ),
+        ):
+            assert AreaSelectorDialog.select_area(
+                initial_rect=(1, 2, 3, 4)
+            ) == (10, 20, 100, 200)
+
+    def test_get_selected_rect_returns_none_for_too_small_rect(self) -> None:
+        """Невалидная область не должна считаться выбранной."""
+        dialog = self._create_dialog()
+        dialog._selection = (1, 1, 4, 4)
+        assert dialog.get_selected_rect() is None
+
+    def test_event_point_supports_position_api(self) -> None:
+        """Selector читает координаты из position() в стиле Qt6."""
+        dialog = self._create_dialog()
+        event = _FakeMouseEvent(30, 40, button=1, use_position=True)
+        assert dialog._event_point(event) == (30, 40)
+
+    def test_mouse_press_move_and_release_create_selection(self) -> None:
+        """Последовательность drag создаёт и фиксирует область."""
+        dialog = self._create_dialog()
+        left_button = object()
+        qt_patch = SimpleNamespace(
+            MouseButton=SimpleNamespace(LeftButton=left_button)
+        )
+
+        with patch("gui.views.area_selector.Qt", qt_patch):
+            dialog.mousePressEvent(_FakeMouseEvent(10, 20, left_button))
+            dialog.mouseMoveEvent(_FakeMouseEvent(110, 220, left_button))
+            dialog.mouseReleaseEvent(_FakeMouseEvent(110, 220, left_button))
+
+        assert dialog.get_selected_rect() == (10, 20, 110, 220)
+        assert dialog.update.called
+
+    def test_mouse_press_inside_selection_switches_to_move_mode(self) -> None:
+        """Клик внутри рамки включает режим перемещения."""
+        dialog = self._create_dialog()
+        dialog._selection = (10, 20, 110, 220)
+        left_button = object()
+        qt_patch = SimpleNamespace(
+            MouseButton=SimpleNamespace(LeftButton=left_button)
+        )
+
+        with patch("gui.views.area_selector.Qt", qt_patch):
+            dialog.mousePressEvent(_FakeMouseEvent(30, 50, left_button))
+
+        assert dialog._drag_mode == "move"
+        assert dialog._move_offset == (20, 30)
+
+    def test_mouse_double_click_accepts_when_inside_selection(self) -> None:
+        """Двойной клик внутри области подтверждает выбор."""
+        dialog = self._create_dialog()
+        dialog._selection = (10, 20, 110, 220)
+
+        dialog.mouseDoubleClickEvent(_FakeMouseEvent(50, 70, button=1))
+
+        dialog.selection_completed.emit.assert_called_once_with(
+            (10, 20, 110, 220)
+        )
+        dialog.accept.assert_called_once()
+
+    def test_key_press_handles_escape_and_enter(self) -> None:
+        """Escape отменяет, Enter подтверждает выбранную область."""
+        dialog = self._create_dialog()
+        dialog._selection = (10, 20, 110, 220)
+        qt_patch = SimpleNamespace(
+            Key=SimpleNamespace(
+                Key_Escape="esc", Key_Return="ret", Key_Enter="ent"
+            )
+        )
+
+        with patch("gui.views.area_selector.Qt", qt_patch):
+            dialog.keyPressEvent(_FakeKeyEvent("esc"))
+            dialog.keyPressEvent(_FakeKeyEvent("ret"))
+
+        dialog.reject.assert_called_once()
+        dialog.selection_completed.emit.assert_called_once_with(
+            (10, 20, 110, 220)
+        )
+        dialog.accept.assert_called_once()
 
 
 class TestCaptureViewGraphicSelection:

--- a/tests/unit/test_capture_area_selector.py
+++ b/tests/unit/test_capture_area_selector.py
@@ -1,0 +1,184 @@
+"""
+Тесты графического выбора области захвата.
+"""
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from config import ConfigManager
+from gui.controllers.settings_controller import SettingsController
+from gui.models.recording_state import CaptureType, RecordingState
+from gui.views.area_selector import (
+    describe_rect,
+    format_rect_coords,
+    move_rect,
+    normalize_rect_coords,
+    resize_rect,
+)
+from gui.views.capture_view import CaptureView
+
+if TYPE_CHECKING:
+    from PyQt6.QtWidgets import QApplication
+
+
+class TestAreaSelectorHelpers:
+    """Тесты чистых хелперов selector-а."""
+
+    def test_normalize_rect_coords_reorders_points(self) -> None:
+        """Координаты нормализуются независимо от направления выделения."""
+        result = normalize_rect_coords((500, 400), (100, 200))
+        assert result == (100, 200, 500, 400)
+
+    def test_move_rect_stays_inside_bounds(self) -> None:
+        """Перемещение не выпускает область за границы экрана."""
+        result = move_rect((100, 100, 400, 300), (900, 700), (0, 0, 1000, 800))
+        assert result == (700, 600, 1000, 800)
+
+    def test_resize_rect_clamps_to_bounds(self) -> None:
+        """Изменение размера ограничивается экраном."""
+        result = resize_rect((100, 100), (1400, 900), (0, 0, 1280, 720))
+        assert result == (100, 100, 1280, 720)
+
+    def test_describe_rect_includes_size(self) -> None:
+        """Сводка содержит позицию и размер области."""
+        summary = describe_rect((10, 20, 210, 120))
+        assert "10, 20" in summary
+        assert "200 × 100" in summary
+
+    def test_format_rect_coords(self) -> None:
+        """Координаты форматируются в строку для GUI."""
+        assert format_rect_coords((1, 2, 3, 4)) == "1, 2, 3, 4"
+
+
+class TestCaptureViewGraphicSelection:
+    """Тесты интеграции CaptureView с selector-ом."""
+
+    def test_select_rectangle_updates_view_and_emits_signal(
+        self, qapp: "QApplication"
+    ) -> None:
+        """Выбор области обновляет UI и отправляет сигнал."""
+        with (
+            patch(
+                "gui.views.capture_view.get_available_windows", return_value=[]
+            ),
+            patch(
+                "gui.views.capture_view.get_screen_size",
+                return_value=(1920, 1080),
+            ),
+            patch(
+                "gui.views.capture_view.AreaSelectorDialog.select_area",
+                return_value=(100, 120, 500, 420),
+            ),
+        ):
+            view = CaptureView()
+            received: list[tuple[int, int, int, int]] = []
+            view.rect_selected.connect(received.append)
+
+            view._select_rectangle()
+
+            assert view.get_capture_type() == CaptureType.RECT
+            assert view.get_rect_coords() == (100, 120, 500, 420)
+            assert view._rect_edit.text() == "100, 120, 500, 420"
+            assert "400 × 300" in view._rect_summary_label.text()
+            assert view._rect_preview._rect_coords == (100, 120, 500, 420)
+            assert received == [(100, 120, 500, 420)]
+
+    def test_set_rect_coords_updates_preview_state(
+        self,
+        qapp: "QApplication",
+    ) -> None:
+        """Программная установка координат синхронизирует preview."""
+        with (
+            patch(
+                "gui.views.capture_view.get_available_windows", return_value=[]
+            ),
+            patch(
+                "gui.views.capture_view.get_screen_size",
+                return_value=(2560, 1440),
+            ),
+        ):
+            view = CaptureView()
+
+            view.set_rect_coords((50, 60, 350, 260))
+
+            assert view.get_rect_coords() == (50, 60, 350, 260)
+            assert view._rect_edit.text() == "50, 60, 350, 260"
+            assert "300 × 200" in view._rect_summary_label.text()
+            assert view._rect_preview._rect_coords == (50, 60, 350, 260)
+
+    def test_cancelled_selection_keeps_empty_state(
+        self,
+        qapp: "QApplication",
+    ) -> None:
+        """Отмена selector-а не меняет текущие координаты."""
+        with (
+            patch(
+                "gui.views.capture_view.get_available_windows", return_value=[]
+            ),
+            patch(
+                "gui.views.capture_view.get_screen_size",
+                return_value=(1920, 1080),
+            ),
+            patch(
+                "gui.views.capture_view.AreaSelectorDialog.select_area",
+                return_value=None,
+            ),
+        ):
+            view = CaptureView()
+
+            view._select_rectangle()
+
+            assert view.get_rect_coords() is None
+            assert view._rect_edit.text() == ""
+            assert view._rect_summary_label.text() == "Область не выбрана"
+
+
+class TestSettingsControllerCapturePersistence:
+    """Тесты загрузки и сохранения capture-настроек."""
+
+    def test_load_capture_settings(self) -> None:
+        """Capture-настройки загружаются в модель состояния."""
+        config = MagicMock(spec=ConfigManager)
+        config.settings.video.fps = 30
+        config.settings.video.codec = "libx264"
+        config.settings.video.bitrate = "2M"
+        config.settings.video.format = "mp4"
+        config.settings.capture.area_type = "rect"
+        config.settings.capture.window_title = "Editor"
+        config.settings.capture.rect_coords = [10, 20, 300, 200]
+        config.settings.output.default_path = ""
+        config.settings.recent_recordings = []
+
+        state = RecordingState()
+        controller = SettingsController(state=state, config=config)
+
+        controller.load_settings()
+
+        assert state.capture.capture_type == CaptureType.RECT
+        assert state.capture.window_title == "Editor"
+        assert state.capture.rect_coords == (10, 20, 300, 200)
+
+    def test_save_capture_settings(self) -> None:
+        """Capture-настройки сохраняются обратно в конфиг."""
+        config = MagicMock(spec=ConfigManager)
+        config.settings.video.fps = 30
+        config.settings.video.codec = "libx264"
+        config.settings.video.bitrate = "2M"
+        config.settings.video.format = "mp4"
+        config.settings.capture.area_type = "full"
+        config.settings.capture.window_title = None
+        config.settings.capture.rect_coords = None
+        config.settings.output.default_path = ""
+        config.settings.recent_recordings = []
+
+        state = RecordingState()
+        state.capture.capture_type = CaptureType.RECT
+        state.capture.window_title = "Browser"
+        state.capture.rect_coords = (100, 120, 800, 600)
+        controller = SettingsController(state=state, config=config)
+
+        controller.save_settings()
+
+        assert config.settings.capture.area_type == "rect"
+        assert config.settings.capture.window_title == "Browser"
+        assert config.settings.capture.rect_coords == [100, 120, 800, 600]

--- a/tests/unit/test_main_window.py
+++ b/tests/unit/test_main_window.py
@@ -8,8 +8,50 @@ Unit тесты для MainWindow
 """
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+from core.recording_types import AudioMode, CaptureMode
+from gui.models.recording_state import (
+    AudioSettings,
+    RecordingState,
+    VideoSettings,
+)
+
+
+def _build_window():
+    """Создать MainWindow без запуска тяжёлого __init__."""
+    from gui.main_window import MainWindow
+
+    window = MainWindow.__new__(MainWindow)
+    window._state = RecordingState()
+    window._settings_controller = MagicMock()
+    window._recording_controller = MagicMock()
+    window._capture_view = MagicMock()
+    window._video_view = MagicMock()
+    window._output_view = MagicMock()
+    window._api_settings_view = MagicMock()
+    window._api_controls = {}
+    window._api_server = None
+    window._ws_controller = None
+    window.start_btn = MagicMock()
+    window.stop_btn = MagicMock()
+    window.pause_btn = MagicMock()
+    window.status_label = MagicMock()
+    window.time_label = MagicMock()
+    window.status_bar = MagicMock()
+    window._ws_status_label = MagicMock()
+    window.recording_started = MagicMock()
+    window.recording_stopped = MagicMock()
+    window.recording_paused = MagicMock()
+    window.recording_resumed = MagicMock()
+    window.error_occurred = MagicMock()
+    window.recordings_list = MagicMock()
+    window._recordings_filter_input = MagicMock()
+    window._diagnostics_view = MagicMock()
+    return window
 
 
 class TestMainWindowBasics:
@@ -507,6 +549,532 @@ class TestMainWindowElapsedtime:
 
         assert state.recording_start_time is not None
         assert before <= state.recording_start_time <= after
+
+
+class TestMainWindowMethods:
+    """Тесты методов MainWindow без полного GUI-init."""
+
+    def test_apply_settings_to_views_applies_rect_capture_and_output(
+        self,
+    ) -> None:
+        """Настройки capture/output переносятся в соответствующие view."""
+        window = _build_window()
+        window._state.capture.capture_type = CaptureMode.RECT
+        window._state.capture.window_title = "Editor"
+        window._state.capture.rect_coords = (10, 20, 300, 200)
+        window._state.output.default_path = "D:/Recordings"
+        window._refresh_recent_recordings = MagicMock()
+
+        window._apply_settings_to_views()
+
+        window._capture_view.set_capture_type.assert_called_once_with(
+            CaptureMode.RECT
+        )
+        window._capture_view.set_window_title.assert_called_once_with("Editor")
+        window._capture_view.set_rect_coords.assert_called_once_with(
+            (10, 20, 300, 200)
+        )
+        window._video_view.set_settings.assert_called_once_with(
+            window._state.video
+        )
+        window._output_view.set_output_path.assert_called_once_with(
+            "D:/Recordings"
+        )
+        window._refresh_recent_recordings.assert_called_once()
+
+    def test_refresh_recent_recordings_adds_only_existing_matching_items(
+        self, tmp_path: Path
+    ) -> None:
+        """В список попадают только существующие записи, прошедшие фильтр."""
+        from core.recording_state import RecentRecording
+
+        window = _build_window()
+        existing = tmp_path / "capture.mp4"
+        existing.write_bytes(b"data")
+        missing = tmp_path / "missing.mp4"
+        window._state.recent_recordings = [
+            RecentRecording(path=existing, size=42, date="2026-04-03"),
+            RecentRecording(path=missing, size=100, date="2026-04-03"),
+        ]
+        window._recordings_filter_input.text.return_value = "capture"
+
+        class FakeListWidgetItem:
+            def __init__(self, text: str) -> None:
+                self.text = text
+                self.payload = None
+
+            def setData(self, _role, payload: str) -> None:
+                self.payload = payload
+
+        added_items: list[FakeListWidgetItem] = []
+        window.recordings_list.addItem.side_effect = added_items.append
+
+        with (
+            patch("gui.main_window.QListWidgetItem", FakeListWidgetItem),
+            patch("gui.main_window.format_filesize", return_value="42 B"),
+        ):
+            window._refresh_recent_recordings()
+
+        window.recordings_list.clear.assert_called_once()
+        assert len(added_items) == 1
+        assert added_items[0].text == "capture.mp4 - 42 B - 2026-04-03"
+        assert added_items[0].payload == str(existing)
+
+    @pytest.mark.parametrize(
+        ("filename", "date_text", "filter_text", "expected"),
+        [
+            ("capture.mp4", "2026-04-03", "", True),
+            ("capture.mp4", "2026-04-03", "CAPTURE", True),
+            ("capture.mp4", "2026-04-03", "2026-04", True),
+            ("capture.mp4", "2026-04-03", "other", False),
+        ],
+    )
+    def test_recording_matches_filter(
+        self,
+        filename: str,
+        date_text: str,
+        filter_text: str,
+        expected: bool,
+    ) -> None:
+        """Фильтр учитывает имя файла и дату без учёта регистра."""
+        from gui.main_window import MainWindow
+
+        assert (
+            MainWindow._recording_matches_filter(
+                filename,
+                date_text,
+                filter_text,
+            )
+            is expected
+        )
+
+    def test_clear_recordings_filter_resets_field_and_refreshes(self) -> None:
+        """Сброс фильтра очищает поле и обновляет список."""
+        window = _build_window()
+        window._refresh_recent_recordings = MagicMock()
+
+        window._clear_recordings_filter()
+
+        window._recordings_filter_input.setText.assert_called_once_with("")
+        window._refresh_recent_recordings.assert_called_once()
+
+    def test_on_view_signal_handlers_forward_to_settings_controller(
+        self,
+    ) -> None:
+        """Сигналы view проксируются в SettingsController."""
+        window = _build_window()
+        settings = VideoSettings(
+            fps=60, codec="libx265", bitrate="5M", format="avi"
+        )
+
+        window._on_capture_type_changed(CaptureMode.WINDOW)
+        window._on_window_selected("Editor")
+        window._on_rect_selected((1, 2, 3, 4))
+        window._on_audio_type_changed(AudioMode.SYSTEM)
+        window._on_mic_device_changed(7)
+        window._on_video_settings_changed(settings)
+        window._on_output_path_changed("D:/out.mp4")
+
+        window._settings_controller.update_capture_settings.assert_any_call(
+            capture_type=CaptureMode.WINDOW
+        )
+        window._settings_controller.update_capture_settings.assert_any_call(
+            window_title="Editor"
+        )
+        window._settings_controller.update_capture_settings.assert_any_call(
+            rect_coords=(1, 2, 3, 4)
+        )
+        window._settings_controller.update_audio_settings.assert_any_call(
+            audio_type=AudioMode.SYSTEM
+        )
+        window._settings_controller.update_audio_settings.assert_any_call(
+            mic_device_index=7
+        )
+        window._settings_controller.update_video_settings.assert_called_once_with(
+            fps=60,
+            codec="libx265",
+            bitrate="5M",
+            format="avi",
+        )
+        window._output_view.set_default_format.assert_called_once_with("avi")
+        window._settings_controller.update_output_settings.assert_called_once_with(
+            output_path="D:/out.mp4"
+        )
+
+    def test_start_recording_shows_error_for_rect_without_coords(self) -> None:
+        """Для RECT без координат запуск записи блокируется."""
+        window = _build_window()
+        window._capture_view.get_capture_type.return_value = CaptureMode.RECT
+        window._capture_view.get_rect_coords.return_value = None
+        window._show_error = MagicMock()
+
+        window._start_recording()
+
+        window._show_error.assert_called_once()
+        window._recording_controller.start_recording.assert_not_called()
+
+    def test_start_recording_uses_fallback_full_screen_rect(self) -> None:
+        """Без rect_coords используется fallback на размер экрана."""
+        window = _build_window()
+        window._capture_view.get_capture_type.return_value = CaptureMode.FULL
+        window._capture_view.get_rect_coords.return_value = None
+        window._capture_view.get_window_title.return_value = ""
+        window._video_view.get_settings.return_value = VideoSettings()
+        window._settings_controller.get_output_path.return_value = Path(
+            "D:/capture.mp4"
+        )
+        window._recording_controller.start_recording.return_value = (
+            True,
+            None,
+        )
+        window._on_recording_started = MagicMock()
+
+        class FakeGeometry:
+            def width(self) -> int:
+                return 1600
+
+            def height(self) -> int:
+                return 900
+
+        fake_screen = SimpleNamespace(geometry=lambda: FakeGeometry())
+
+        with patch(
+            "PyQt6.QtGui.QGuiApplication.primaryScreen",
+            return_value=fake_screen,
+        ):
+            window._start_recording()
+
+        call = window._recording_controller.start_recording.call_args.kwargs
+        assert call["capture"].rect_coords == (0, 0, 1600, 900)
+        window._on_recording_started.assert_called_once_with(
+            Path("D:/capture.mp4")
+        )
+
+    def test_stop_recording_reports_missing_output(self) -> None:
+        """Если backend не вернул путь, показывается ошибка."""
+        window = _build_window()
+        window._state.start_recording(Path("D:/capture.mp4"))
+        window._recording_controller.stop_recording.return_value = None
+        window._show_error = MagicMock()
+
+        window._stop_recording()
+
+        window._show_error.assert_called_once()
+
+    def test_toggle_pause_calls_expected_controller_branch(self) -> None:
+        """Переключение паузы вызывает pause или resume ветку."""
+        window = _build_window()
+        window._on_recording_paused = MagicMock()
+        window._on_recording_resumed = MagicMock()
+
+        window._toggle_pause()
+        window._recording_controller.pause_recording.assert_called_once()
+        window._on_recording_paused.assert_called_once()
+
+        window._state.start_recording(Path("D:/capture.mp4"))
+        window._state.pause_recording()
+        window._toggle_pause()
+        window._recording_controller.resume_recording.assert_called_once()
+        window._on_recording_resumed.assert_called_once()
+
+    def test_on_recording_started_and_resumed_update_controls(self) -> None:
+        """UI обновляется при старте, паузе и возобновлении записи."""
+        window = _build_window()
+        output = Path("D:/capture.mp4")
+
+        window._on_recording_started(output)
+        window._on_recording_paused()
+        window._on_recording_resumed()
+
+        window.start_btn.setEnabled.assert_called_with(False)
+        window.stop_btn.setEnabled.assert_called_with(True)
+        window.pause_btn.setText.assert_any_call("Пауза")
+        window.pause_btn.setText.assert_any_call("Продолжить")
+        window.status_label.setText.assert_any_call("Запись")
+        window.status_label.setText.assert_any_call("Пауза")
+        window.recording_started.emit.assert_called_once_with(str(output))
+        window.recording_paused.emit.assert_called_once()
+        window.recording_resumed.emit.assert_called_once()
+
+    def test_on_recording_stopped_adds_recent_recording_for_existing_file(
+        self, tmp_path: Path
+    ) -> None:
+        """Остановка записи добавляет существующий файл в recent recordings."""
+        window = _build_window()
+        output = tmp_path / "capture.mp4"
+        output.write_bytes(b"abc")
+        window._refresh_recent_recordings = MagicMock()
+
+        window._on_recording_stopped(output)
+
+        window._settings_controller.add_recent_recording.assert_called_once_with(
+            output,
+            3,
+        )
+        window._refresh_recent_recordings.assert_called_once()
+        window.recording_stopped.emit.assert_called_once_with(str(output))
+
+    def test_update_status_formats_elapsed_time(self) -> None:
+        """Таймер статуса форматирует elapsed time во время записи."""
+        window = _build_window()
+        window._state.start_recording(Path("D:/capture.mp4"))
+        window._recording_controller.elapsed_time = 12.34
+
+        with patch("gui.main_window.format_time", return_value="00:12"):
+            window._update_status()
+
+        window.time_label.setText.assert_called_once_with("00:12")
+
+    def test_invoke_api_control_handles_none_exception_and_plain_value(
+        self,
+    ) -> None:
+        """Вызов API control нормализует ответы и ошибки."""
+        window = _build_window()
+        window._show_error = MagicMock()
+        window._api_controls = {
+            "ping": lambda: "pong",
+            "boom": lambda: (_ for _ in ()).throw(RuntimeError("fail")),
+        }
+
+        assert window._invoke_api_control("missing") is None
+        assert window._invoke_api_control("ping") == {
+            "success": True,
+            "data": "pong",
+        }
+        assert window._invoke_api_control("boom") is None
+        window._show_error.assert_called_once_with("fail")
+
+    def test_refresh_api_status_uses_result_and_fallback_server(self) -> None:
+        """Статус API берётся из control-а или из резервного сервера."""
+        window = _build_window()
+        window._invoke_api_control = MagicMock(
+            side_effect=[
+                {
+                    "configured": {"port": 8080, "api_key": "secret"},
+                    "running": True,
+                    "url": "http://127.0.0.1:8080",
+                },
+                None,
+            ]
+        )
+        window._api_server = MagicMock()
+        window._api_server.is_running.return_value = False
+        window._api_settings_view.is_editing_settings.return_value = False
+
+        window._refresh_api_status()
+        window._refresh_api_status()
+
+        window._api_settings_view.set_settings.assert_called_once_with(
+            port=8080,
+            token="secret",
+        )
+        window._api_settings_view.set_status.assert_any_call(
+            True,
+            "Запущен: http://127.0.0.1:8080",
+        )
+        window._api_settings_view.set_status.assert_any_call(
+            False,
+            "Сервер остановлен",
+        )
+
+    def test_api_button_handlers_route_success_and_failure(self) -> None:
+        """Хендлеры API-кнопок обновляют статусбар и ошибки."""
+        window = _build_window()
+        window._show_error = MagicMock()
+        window._refresh_api_status = MagicMock()
+        window._start_websocket_after_api = MagicMock()
+        window.disconnect_websocket = MagicMock()
+        window._invoke_api_control = MagicMock(
+            side_effect=[
+                {"success": True, "restart_required": True},
+                {
+                    "success": True,
+                    "configured": {"api_key": "t"},
+                    "url": "http://x",
+                },
+                {"success": True},
+                {"success": False, "error": "restart failed"},
+            ]
+        )
+
+        window._on_api_settings_apply(9000, "tok")
+        window._on_api_start()
+        window._on_api_stop()
+        window._on_api_restart()
+
+        assert window.status_bar.showMessage.call_count >= 3
+        window._start_websocket_after_api.assert_called_once()
+        window.disconnect_websocket.assert_called()
+        window._show_error.assert_called_with("restart failed")
+
+    def test_start_websocket_after_api_initializes_only_when_url_and_token(
+        self,
+    ) -> None:
+        """WebSocket стартует только при наличии URL и токена."""
+        window = _build_window()
+        window.init_websocket_client = MagicMock()
+        window.connect_websocket = MagicMock()
+
+        window._start_websocket_after_api(
+            {
+                "configured": {"api_key": "token"},
+                "url": "http://127.0.0.1:5000",
+            }
+        )
+        window._ws_controller = MagicMock()
+        window._start_websocket_after_api(
+            {
+                "configured": {"api_key": "token"},
+                "url": "http://127.0.0.1:5000",
+            }
+        )
+        window._start_websocket_after_api({"configured": {}, "url": ""})
+
+        window.init_websocket_client.assert_called_once_with(
+            "http://127.0.0.1:5000",
+            "token",
+        )
+        assert window.connect_websocket.call_count == 2
+
+    def test_websocket_helpers_update_status_and_emit_events(self) -> None:
+        """WebSocket-хелперы обновляют label и проксируют события."""
+        window = _build_window()
+
+        window._on_ws_status_changed("connected")
+        window._on_ws_event_received(
+            "recording.started", {"output_path": "D:/capture.mp4"}
+        )
+        window._on_ws_event_received("recording.paused", {})
+        window._on_ws_event_received("recording.resumed", {})
+        window._on_ws_event_received("recording.error", {"error": "boom"})
+
+        window._ws_status_label.setText.assert_called_with("WS: ●")
+        window.recording_started.emit.assert_called_once_with("D:/capture.mp4")
+        window.recording_paused.emit.assert_called_once()
+        window.recording_resumed.emit.assert_called_once()
+        window.error_occurred.emit.assert_called_once_with("boom")
+
+    def test_open_recording_helpers_use_selected_items(self) -> None:
+        """Открытие записей использует выбранный и последний элементы."""
+        window = _build_window()
+        window._open_file = MagicMock()
+        fake_item = MagicMock()
+        fake_item.data.return_value = "D:/capture.mp4"
+        window.recordings_list.currentItem.return_value = fake_item
+        window.recordings_list.item.return_value = fake_item
+
+        window._open_recording(fake_item)
+        window._open_selected_recording()
+        window._open_latest_recording()
+
+        assert window._open_file.call_count == 3
+
+    @pytest.mark.parametrize(
+        ("requested", "fmt", "expected"),
+        [
+            (None, "mp4", Path("D:/default.mp4")),
+            ("  ", "mp4", Path("D:/default.mp4")),
+            ("relative_video", "mkv", Path("relative_video.mkv")),
+            ("relative_video.mp4", "mkv", Path("relative_video.mp4")),
+        ],
+    )
+    def test_resolve_requested_output_path_basic_variants(
+        self,
+        requested: str | None,
+        fmt: str,
+        expected: Path,
+    ) -> None:
+        """output_path из API нормализуется в итоговый путь файла."""
+        window = _build_window()
+        window._settings_controller.get_output_path.return_value = Path(
+            "D:/default.mp4"
+        )
+
+        result = window._resolve_requested_output_path(requested, fmt)
+
+        assert result == expected
+
+    def test_resolve_requested_output_path_for_directory_hint(self) -> None:
+        """Путь с завершающим слешем трактуется как директория."""
+        window = _build_window()
+
+        with patch("gui.main_window.datetime") as mocked_datetime:
+            mocked_datetime.now.return_value.strftime.return_value = (
+                "20260403_123456"
+            )
+            result = window._resolve_requested_output_path("D:/out/", "mp4")
+
+        assert result == Path("D:/out/recording_20260403_123456.mp4")
+
+    def test_start_recording_with_params_success_and_invalid_rect(
+        self,
+    ) -> None:
+        """API-старт записи обрабатывает успешный и невалидный rect кейсы."""
+        window = _build_window()
+        window._video_view.get_settings.return_value = VideoSettings()
+        window._recording_controller.start_recording.return_value = (
+            True,
+            None,
+        )
+        window._resolve_requested_output_path = MagicMock(
+            return_value=Path("D:/capture.mp4")
+        )
+        window._on_recording_started = MagicMock()
+
+        result = window.start_recording_with_params(
+            {
+                "area": "rect",
+                "rect": [10, 20, 110, 220],
+                "audio": "system",
+                "fps": 60,
+                "codec": "libx265",
+                "bitrate": "5M",
+            }
+        )
+        invalid = window.start_recording_with_params(
+            {"area": "rect", "rect": [1, 2, 3]}
+        )
+
+        assert result == {
+            "success": True,
+            "output_path": str(Path("D:/capture.mp4")),
+        }
+        call = window._recording_controller.start_recording.call_args.kwargs
+        assert call["capture"].rect_coords == (10, 20, 110, 220)
+        assert isinstance(call["audio"], AudioSettings)
+        assert invalid["success"] is False
+        assert "4 координаты" in invalid["error"]
+
+    def test_stop_recording_toggle_pause_and_get_recordings_api_methods(
+        self,
+    ) -> None:
+        """API-методы stop/pause/read работают с текущим состоянием."""
+        window = _build_window()
+        window._on_recording_stopped = MagicMock()
+        window._on_recording_paused = MagicMock()
+        window._recording_controller.stop_recording.return_value = Path(
+            "D:/capture.mp4"
+        )
+
+        assert window.stop_recording()["success"] is False
+        assert window.toggle_pause()["success"] is False
+
+        window._state.start_recording(Path("D:/capture.mp4"))
+        stop_result = window.stop_recording()
+        pause_result = window.toggle_pause()
+
+        with patch("gui.main_window.get_config") as mocked_get_config:
+            mocked_get_config.return_value.settings.recent_recordings = [
+                {"path": "D:/capture.mp4"}
+            ]
+            recordings = window.get_recordings()
+
+        assert stop_result == {
+            "success": True,
+            "filepath": str(Path("D:/capture.mp4")),
+        }
+        assert pause_result == {"success": True, "is_paused": True}
+        assert recordings == [{"path": "D:/capture.mp4"}]
 
     def test_recording_start_time_cleared_on_stop(self) -> None:
         """Проверка очистки времени начала при остановке."""


### PR DESCRIPTION
## Что сделано
- добавлен overlay для графического выбора прямоугольной области мышью
- добавлен preview выбранной области и текстовая сводка координат/размера
- восстановлена загрузка и сохранение capture-настроек в GUI
- добавлены unit-тесты на selector, CaptureView и persistence настроек

## Проверки
- python -m pytest tests/unit/test_capture_area_selector.py tests/unit/test_main_window.py tests/unit/test_settings_controller.py -q
- ruff check gui/views/area_selector.py gui/views/capture_view.py gui/main_window.py gui/controllers/settings_controller.py tests/unit/test_capture_area_selector.py
- python -m mypy --follow-imports skip gui/views/area_selector.py gui/views/capture_view.py gui/main_window.py gui/controllers/settings_controller.py tests/unit/test_capture_area_selector.py

Closes #24