### PR TITLE
Вынести конфигурацию видеокодеков в единый каталог

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 - Проверка доступности FFmpeg кэшируется на короткий TTL в
   `RecordingController`, чтобы единообразно покрывать GUI/API/scheduler
   path без лишних повторных вызовов `ffmpeg -version`.
+- Конфигурация видеокодеков GUI вынесена в единый каталог
+  `gui.models.video_codecs`; `VideoView` больше не хранит локальные
+  дублирующиеся маппинги `display <-> codec id`.
 
 ### Tests
 - Добавлены unit-тесты на stop/cancel flow долгой остановки записи в
@@ -38,6 +41,8 @@
 - Добавлены unit-тесты на reconnect/finalization сценарии при потере
   захвата экрана.
 - Добавлен regression test на cron weekday semantics в scheduler.
+- Добавлены unit-тесты каталога видеокодеков и актуализированы
+  проверки `VideoView` под единый порядок кодеков.
 
 ## [1.4.7] - 2026-04-03
 

--- a/gui/models/video_codecs.py
+++ b/gui/models/video_codecs.py
@@ -1,0 +1,93 @@
+"""Единый источник данных о доступных видеокодеках GUI."""
+
+from dataclasses import dataclass
+
+DEFAULT_CODEC_ID = "libx264"
+
+
+@dataclass(frozen=True, slots=True)
+class CodecInfo:
+    """Описание доступного видеокодека."""
+
+    codec_id: str
+    display_name: str
+    description: str
+    hardware_acceleration: bool = False
+
+
+AVAILABLE_VIDEO_CODECS: tuple[CodecInfo, ...] = (
+    CodecInfo(
+        codec_id="libx264",
+        display_name="libx264 (CPU)",
+        description="Программный кодек H.264.",
+    ),
+    CodecInfo(
+        codec_id="h264_nvenc",
+        display_name="h264_nvenc (NVIDIA GPU)",
+        description="Аппаратное кодирование NVIDIA H.264.",
+        hardware_acceleration=True,
+    ),
+    CodecInfo(
+        codec_id="h264_qsv",
+        display_name="h264_qsv (Intel GPU)",
+        description="Аппаратное кодирование Intel Quick Sync H.264.",
+        hardware_acceleration=True,
+    ),
+    CodecInfo(
+        codec_id="libx265",
+        display_name="libx265 (HEVC CPU)",
+        description="Программный кодек H.265/HEVC.",
+    ),
+    CodecInfo(
+        codec_id="hevc_nvenc",
+        display_name="hevc_nvenc (NVIDIA HEVC)",
+        description="Аппаратное кодирование NVIDIA HEVC.",
+        hardware_acceleration=True,
+    ),
+    CodecInfo(
+        codec_id="mp4v",
+        display_name="mp4v",
+        description="MPEG-4 Visual.",
+    ),
+)
+
+_CODEC_BY_ID = {codec.codec_id: codec for codec in AVAILABLE_VIDEO_CODECS}
+_CODEC_BY_DISPLAY_NAME = {
+    codec.display_name: codec for codec in AVAILABLE_VIDEO_CODECS
+}
+
+
+def get_available_codec_display_names() -> list[str]:
+    """Вернуть display-имена кодеков в порядке показа в UI."""
+
+    return [codec.display_name for codec in AVAILABLE_VIDEO_CODECS]
+
+
+def get_codec_info_by_id(codec_id: str) -> CodecInfo | None:
+    """Найти описание кодека по идентификатору."""
+
+    return _CODEC_BY_ID.get(codec_id)
+
+
+def get_codec_info_by_display_name(display_name: str) -> CodecInfo | None:
+    """Найти описание кодека по display-имени."""
+
+    return _CODEC_BY_DISPLAY_NAME.get(display_name)
+
+
+def codec_id_from_display_name(display_name: str) -> str:
+    """Преобразовать display-имя в идентификатор кодека."""
+
+    codec = get_codec_info_by_display_name(display_name)
+    if codec is None:
+        return DEFAULT_CODEC_ID
+    return codec.codec_id
+
+
+def display_name_from_codec_id(codec_id: str) -> str:
+    """Преобразовать идентификатор кодека в display-имя."""
+
+    codec = get_codec_info_by_id(codec_id)
+    if codec is None:
+        return _CODEC_BY_ID[DEFAULT_CODEC_ID].display_name
+    return codec.display_name

--- a/gui/views/video_view.py
+++ b/gui/views/video_view.py
@@ -17,6 +17,11 @@ from PyQt6.QtWidgets import (
 )
 
 from gui.models.recording_state import VideoSettings
+from gui.models.video_codecs import (
+    codec_id_from_display_name,
+    display_name_from_codec_id,
+    get_available_codec_display_names,
+)
 from logger_config import get_module_logger
 
 logger = get_module_logger(__name__)
@@ -70,16 +75,7 @@ class VideoView(QWidget):
         # Кодек
         group_layout.addWidget(QLabel("Кодек:"), 0, 2)
         self._codec_combo = QComboBox()
-        self._codec_combo.addItems(
-            [
-                "libx264 (CPU)",
-                "h264_nvenc (NVIDIA GPU)",
-                "h264_qsv (Intel GPU)",
-                "libx265 (HEVC CPU)",
-                "hevc_nvenc (NVIDIA HEVC)",
-                "mp4v",
-            ]
-        )
+        self._codec_combo.addItems(get_available_codec_display_names())
         group_layout.addWidget(self._codec_combo, 0, 3)
 
         # Битрейт
@@ -172,7 +168,7 @@ class VideoView(QWidget):
         """Отправка сигнала с текущими настройками."""
         settings = VideoSettings(
             fps=self._fps_spin.value(),
-            codec=self._codec_combo.currentText(),
+            codec=self.get_codec(),
             bitrate=self._bitrate_combo.currentText(),
             format=self._format_combo.currentText(),
             preset=self._get_preset_value(),
@@ -190,21 +186,14 @@ class VideoView(QWidget):
 
     def get_codec(self) -> str:
         """
-        Получить выбранный кодек.
+        Получить идентификатор выбранного кодека.
 
         Returns:
-            Название кодека
+            Идентификатор кодека FFmpeg
         """
-        text = self._codec_combo.currentText()
-        codec_map = {
-            "libx264 (CPU)": "libx264",
-            "h264_nvenc (NVIDIA GPU)": "h264_nvenc",
-            "h264_qsv (Intel GPU)": "h264_qsv",
-            "libx265 (HEVC CPU)": "libx265",
-            "hevc_nvenc (NVIDIA HEVC)": "hevc_nvenc",
-            "mp4v": "mp4v",
-        }
-        return codec_map.get(text, "libx264")
+        current_text: str = self._codec_combo.currentText()
+        codec_id: str = codec_id_from_display_name(current_text)
+        return codec_id
 
     def get_bitrate(self) -> str:
         """
@@ -213,7 +202,8 @@ class VideoView(QWidget):
         Returns:
             Значение битрейта
         """
-        return self._bitrate_combo.currentText()
+        bitrate: str = self._bitrate_combo.currentText()
+        return bitrate
 
     def get_format(self) -> str:
         """
@@ -222,7 +212,8 @@ class VideoView(QWidget):
         Returns:
             Формат файла
         """
-        return self._format_combo.currentText()
+        video_format: str = self._format_combo.currentText()
+        return video_format
 
     def get_preset(self) -> str:
         """
@@ -259,20 +250,12 @@ class VideoView(QWidget):
 
     def set_codec(self, codec: str) -> None:
         """
-        Установить кодек.
+        Установить кодек по его идентификатору.
 
         Args:
-            codec: Название кодека
+            codec: Идентификатор кодека FFmpeg
         """
-        codec_to_text = {
-            "libx264": "libx264 (CPU)",
-            "h264_nvenc": "h264_nvenc (NVIDIA GPU)",
-            "h264_qsv": "h264_qsv (Intel GPU)",
-            "libx265": "libx265 (HEVC CPU)",
-            "hevc_nvenc": "hevc_nvenc (NVIDIA HEVC)",
-            "mp4v": "mp4v",
-        }
-        text = codec_to_text.get(codec, "libx264 (CPU)")
+        text: str = display_name_from_codec_id(codec)
         index = self._codec_combo.findText(text)
         if index >= 0:
             self._codec_combo.setCurrentIndex(index)

--- a/tests/unit/test_gui_views.py
+++ b/tests/unit/test_gui_views.py
@@ -479,7 +479,7 @@ class TestVideoViewGetters:
     def test_get_codec(self, qapp: QApplication) -> None:
         """Проверка получения кодека."""
         view = VideoView()
-        view._codec_combo.setCurrentIndex(1)  # mp4v
+        view._codec_combo.setCurrentIndex(5)  # mp4v
         assert view.get_codec() == "mp4v"
 
     def test_get_bitrate(self, qapp: QApplication) -> None:
@@ -498,7 +498,7 @@ class TestVideoViewGetters:
         """Проверка получения настроек."""
         view = VideoView()
         view._fps_spin.setValue(60)
-        view._codec_combo.setCurrentIndex(1)  # mp4v
+        view._codec_combo.setCurrentIndex(5)  # mp4v
         view._bitrate_combo.setCurrentIndex(2)  # 4M
         view._format_combo.setCurrentIndex(1)  # avi
 
@@ -593,7 +593,7 @@ class TestVideoViewSignals:
             signal_received.append(codec)
 
         view.codec_changed.connect(on_codec_changed)
-        view._codec_combo.setCurrentIndex(1)
+        view._codec_combo.setCurrentIndex(5)
 
         assert "mp4v" in signal_received
 

--- a/tests/unit/test_video_codecs.py
+++ b/tests/unit/test_video_codecs.py
@@ -1,0 +1,64 @@
+"""Тесты каталога видеокодеков GUI."""
+
+from gui.models.video_codecs import (
+    AVAILABLE_VIDEO_CODECS,
+    DEFAULT_CODEC_ID,
+    codec_id_from_display_name,
+    display_name_from_codec_id,
+    get_available_codec_display_names,
+    get_codec_info_by_display_name,
+    get_codec_info_by_id,
+)
+
+
+class TestVideoCodecsCatalog:
+    """Проверки единого каталога кодеков."""
+
+    def test_catalog_contains_expected_ids(self) -> None:
+        """Каталог содержит ожидаемые идентификаторы кодеков."""
+        assert [codec.codec_id for codec in AVAILABLE_VIDEO_CODECS] == [
+            "libx264",
+            "h264_nvenc",
+            "h264_qsv",
+            "libx265",
+            "hevc_nvenc",
+            "mp4v",
+        ]
+
+    def test_get_available_codec_display_names(self) -> None:
+        """Каталог возвращает display-имена в UI-порядке."""
+        assert get_available_codec_display_names() == [
+            "libx264 (CPU)",
+            "h264_nvenc (NVIDIA GPU)",
+            "h264_qsv (Intel GPU)",
+            "libx265 (HEVC CPU)",
+            "hevc_nvenc (NVIDIA HEVC)",
+            "mp4v",
+        ]
+
+    def test_get_codec_info_by_id(self) -> None:
+        """Поиск по codec id возвращает ожидаемый объект."""
+        codec = get_codec_info_by_id("h264_nvenc")
+
+        assert codec is not None
+        assert codec.display_name == "h264_nvenc (NVIDIA GPU)"
+        assert codec.hardware_acceleration is True
+
+    def test_get_codec_info_by_display_name(self) -> None:
+        """Поиск по display-имени возвращает ожидаемый объект."""
+        codec = get_codec_info_by_display_name("libx265 (HEVC CPU)")
+
+        assert codec is not None
+        assert codec.codec_id == "libx265"
+
+    def test_codec_id_from_display_name_returns_default_for_unknown(
+        self,
+    ) -> None:
+        """Неизвестное display-имя откатывается к дефолтному codec id."""
+        assert codec_id_from_display_name("unknown") == DEFAULT_CODEC_ID
+
+    def test_display_name_from_codec_id_returns_default_for_unknown(
+        self,
+    ) -> None:
+        """Неизвестный codec id откатывается к дефолтному display text."""
+        assert display_name_from_codec_id("unknown") == "libx264 (CPU)"

--- a/tests/unit/test_video_view.py
+++ b/tests/unit/test_video_view.py
@@ -1,0 +1,190 @@
+"""Тесты VideoView на моках PyQt6."""
+
+from typing import Any
+
+from PyQt6.QtWidgets import QApplication
+
+from gui.models.recording_state import VideoSettings
+from gui.views.video_view import VideoView
+
+
+def _patch_combo_runtime(combo: Any) -> None:
+    """Добавить недостающие методы mock combobox для тестов."""
+
+    def find_text(text: str) -> int:
+        items = getattr(combo, "_items", [])
+        return items.index(text) if text in items else -1
+
+    def set_current_index(index: int) -> None:
+        combo._current_index = index
+        items = getattr(combo, "_items", [])
+        if 0 <= index < len(items):
+            combo._current_text = items[index]
+
+    def set_edit_text(text: str) -> None:
+        combo._current_text = text
+
+    combo.findText = find_text
+    combo.setCurrentIndex = set_current_index
+    combo.setEditText = set_edit_text
+
+
+def _patch_view_runtime(view: VideoView) -> VideoView:
+    """Подготовить моковый VideoView к unit-проверкам."""
+
+    _patch_combo_runtime(view._codec_combo)
+    _patch_combo_runtime(view._bitrate_combo)
+    _patch_combo_runtime(view._format_combo)
+    _patch_combo_runtime(view._preset_combo)
+    return view
+
+
+class TestVideoView:
+    """Проверки VideoView с мокированным PyQt6."""
+
+    def test_init_populates_codec_combo(self, qapp: QApplication) -> None:
+        """Список кодеков заполняется при инициализации."""
+        view = _patch_view_runtime(VideoView())
+
+        assert view._codec_combo.count() == 6
+        assert view._codec_combo.itemText(0) == "libx264 (CPU)"
+        assert view._codec_combo.itemText(5) == "mp4v"
+
+    def test_get_codec_uses_catalog_mapping(self, qapp: QApplication) -> None:
+        """Геттер кодека возвращает codec id, а не display text."""
+        view = _patch_view_runtime(VideoView())
+        view._codec_combo.setCurrentText("h264_nvenc (NVIDIA GPU)")
+
+        assert view.get_codec() == "h264_nvenc"
+
+    def test_get_settings_returns_codec_id(self, qapp: QApplication) -> None:
+        """Текущие настройки возвращают codec id из каталога."""
+        view = _patch_view_runtime(VideoView())
+        view.set_fps(60)
+        view._codec_combo.setCurrentText("mp4v")
+        view._bitrate_combo.setCurrentText("8M")
+        view._format_combo.setCurrentText("avi")
+        view.set_preset("slow")
+
+        settings = view.get_settings()
+
+        assert settings == VideoSettings(
+            fps=60,
+            codec="mp4v",
+            bitrate="8M",
+            format="avi",
+            preset="slow",
+        )
+
+    def test_emit_settings_uses_codec_id(self, qapp: QApplication) -> None:
+        """Сигнал настроек эмитит codec id, а не display text."""
+        view = _patch_view_runtime(VideoView())
+        received: list[VideoSettings] = []
+        view.settings_changed.disconnect()
+        view.settings_changed.connect(received.append)
+
+        view._codec_combo.setCurrentText("h264_qsv (Intel GPU)")
+        view._emit_settings()
+
+        assert received
+        assert received[-1].codec == "h264_qsv"
+
+    def test_set_codec_selects_expected_display_name(
+        self, qapp: QApplication
+    ) -> None:
+        """set_codec выбирает нужный display text по codec id."""
+        view = _patch_view_runtime(VideoView())
+
+        view.set_codec("hevc_nvenc")
+
+        assert view._codec_combo.currentText() == "hevc_nvenc (NVIDIA HEVC)"
+
+    def test_set_codec_unknown_falls_back_to_default(
+        self, qapp: QApplication
+    ) -> None:
+        """Неизвестный codec id откатывается на дефолтный display text."""
+        view = _patch_view_runtime(VideoView())
+
+        view.set_codec("unknown_codec")
+
+        assert view._codec_combo.currentText() == "libx264 (CPU)"
+
+    def test_set_bitrate_supports_existing_and_custom_values(
+        self, qapp: QApplication
+    ) -> None:
+        """set_bitrate работает и для списка, и для custom значения."""
+        view = _patch_view_runtime(VideoView())
+
+        view.set_bitrate("4M")
+        assert view.get_bitrate() == "4M"
+
+        view.set_bitrate("5M")
+        assert view.get_bitrate() == "5M"
+
+    def test_set_format_and_preset(self, qapp: QApplication) -> None:
+        """set_format и set_preset обновляют соответствующие значения."""
+        view = _patch_view_runtime(VideoView())
+
+        view.set_format("mkv")
+        view.set_preset("veryslow")
+
+        assert view.get_format() == "mkv"
+        assert view.get_preset() == "veryslow"
+
+    def test_set_settings_applies_all_video_values(
+        self, qapp: QApplication
+    ) -> None:
+        """set_settings применяет полный набор видеонастроек."""
+        view = _patch_view_runtime(VideoView())
+
+        view.set_settings(
+            VideoSettings(
+                fps=48,
+                codec="libx265",
+                bitrate="10M",
+                format="mkv",
+                preset="fast",
+            )
+        )
+
+        assert view.get_settings() == VideoSettings(
+            fps=48,
+            codec="libx265",
+            bitrate="10M",
+            format="mkv",
+            preset="fast",
+        )
+
+    def test_change_handlers_emit_signals(self, qapp: QApplication) -> None:
+        """Обработчики изменений пробрасывают сигналы наружу."""
+        view = _patch_view_runtime(VideoView())
+        fps_values: list[int] = []
+        codec_values: list[str] = []
+        bitrate_values: list[str] = []
+        format_values: list[str] = []
+        preset_values: list[str] = []
+
+        view.fps_changed.disconnect()
+        view.codec_changed.disconnect()
+        view.bitrate_changed.disconnect()
+        view.format_changed.disconnect()
+        view.preset_changed.disconnect()
+
+        view.fps_changed.connect(fps_values.append)
+        view.codec_changed.connect(codec_values.append)
+        view.bitrate_changed.connect(bitrate_values.append)
+        view.format_changed.connect(format_values.append)
+        view.preset_changed.connect(preset_values.append)
+
+        view._on_fps_changed(75)
+        view._on_codec_changed("mp4v")
+        view._on_bitrate_changed("6M")
+        view._on_format_changed("avi")
+        view.set_preset("slow")
+        view._on_preset_changed(6)
+
+        assert fps_values[-1] == 75
+        assert codec_values[-1] == "mp4v"
+        assert bitrate_values[-1] == "6M"
+        assert format_values[-1] == "avi"
+        assert preset_values[-1] == "slow"


### PR DESCRIPTION
## Что сделано
- вынесен единый каталог видеокодеков в gui.models.video_codecs`n- VideoView переведён на общий маппинг display <-> codec id`n- обновлён CHANGELOG.md и добавлены unit-тесты

## Проверки
- python -m pytest tests/unit/test_video_codecs.py tests/unit/test_gui_views.py -q`n- python -m ruff check --no-cache gui/models/video_codecs.py gui/views/video_view.py tests/unit/test_video_codecs.py tests/unit/test_gui_views.py`n- python -m mypy gui/models/video_codecs.py gui/views/video_view.py`n
Closes #29