### PR TITLE
Reliability: GuiLogBuffer — bounded ring-buffer для live-логов GUI API-вкладки

### DIFF
--- a/gui/AGENTS.md
+++ b/gui/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-04-29 | Updated: 2026-06-23 -->
+<!-- Generated: 2026-04-29 | Updated: 2026-08-16 -->
 
 # gui/
 
@@ -16,6 +16,7 @@ PyQt6 GUI-слой приложения. Реализует MVC-паттерн: 
 | `desktop_actions.py` | `DesktopActions` — действия рабочего стола (уведомления, открытие файлов) |
 | `accessibility.py` | Accessibility атрибуты и ARIA-роли для виджетов |
 | `notifications.py` | `NotificationManager` — системные уведомления через plyer |
+| `log_buffer.py` | `GuiLogBuffer` — потокобезопасный bounded ring-buffer строк лога для GUI-вкладки API. Предотвращает утечку памяти при burst-логировании. Реализует dirty-флаг для дебаунса обновлений виджета. |
 
 ## Subdirectories
 

--- a/gui/log_buffer.py
+++ b/gui/log_buffer.py
@@ -1,0 +1,132 @@
+"""
+Кольцевой буфер для live-логов GUI.
+=====================================
+
+Потокобезопасный буфер с ограниченным размером (ring-buffer) для
+отображения live-логов в GUI API-вкладке.  Предотвращает неограниченный
+рост памяти при высокой интенсивности логирования (burst mode).
+
+Ключевые свойства:
+- Новые строки вытесняют старые при достижении лимита (FIFO eviction).
+- Потокобезопасен: все публичные методы защищены ``threading.Lock``.
+- Поддерживает дебаунс: сброс «грязного» флага позволяет UI опрашивать
+  буфер только при наличии новых данных.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+
+_DEFAULT_MAX_LINES = 2000
+_DEFAULT_MAX_LINE_LENGTH = 2048
+
+
+class GuiLogBuffer:
+    """Потокобезопасный кольцевой буфер строк лога для GUI.
+
+    Args:
+        max_lines: Максимальное число строк в буфере.
+            При превышении самые старые строки вытесняются.
+        max_line_length: Максимальная длина одной строки в символах.
+            Более длинные строки обрезаются с суффиксом ``…``.
+    """
+
+    def __init__(
+        self,
+        max_lines: int = _DEFAULT_MAX_LINES,
+        max_line_length: int = _DEFAULT_MAX_LINE_LENGTH,
+    ) -> None:
+        if max_lines < 1:
+            raise ValueError(
+                f"max_lines должен быть >= 1, получено {max_lines}"
+            )
+        if max_line_length < 1:
+            raise ValueError(
+                f"max_line_length должен быть >= 1, получено {max_line_length}"
+            )
+        self._max_lines = max_lines
+        self._max_line_length = max_line_length
+        self._lines: deque[str] = deque(maxlen=max_lines)
+        self._lock = threading.Lock()
+        self._dirty = False
+        self._evicted_count = 0
+
+    @property
+    def max_lines(self) -> int:
+        """Максимальное количество строк в буфере."""
+        return self._max_lines
+
+    def append(self, text: str) -> None:
+        """Добавляет строки из ``text`` в буфер.
+
+        Текст разбивается по символу новой строки.  Пустые строки
+        игнорируются.  Строки длиннее ``max_line_length`` обрезаются.
+
+        Args:
+            text: Одна или несколько строк лога, разделённых ``\\n``.
+        """
+        if not text:
+            return
+        lines = text.splitlines()
+        with self._lock:
+            before = len(self._lines)
+            for line in lines:
+                if not line:
+                    continue
+                if len(line) > self._max_line_length:
+                    line = line[: self._max_line_length - 1] + "…"
+                self._lines.append(line)
+            # Подсчёт вытесненных строк (deque с maxlen делает это само)
+            added = len(lines)
+            capacity = self._max_lines - before
+            if added > capacity:
+                self._evicted_count += added - capacity
+            self._dirty = True
+
+    def get_text(self) -> str:
+        """Возвращает всё содержимое буфера как единую строку.
+
+        Returns:
+            Строки буфера, соединённые символом перевода строки.
+        """
+        with self._lock:
+            return "\n".join(self._lines)
+
+    def is_dirty(self) -> bool:
+        """Возвращает ``True``, если буфер изменился с последнего сброса.
+
+        Returns:
+            Признак наличия несброшенных изменений.
+        """
+        with self._lock:
+            return self._dirty
+
+    def clear_dirty(self) -> None:
+        """Сбрасывает флаг изменений (dirty-флаг).
+
+        Вызывается GUI-потоком после отрисовки содержимого буфера.
+        """
+        with self._lock:
+            self._dirty = False
+
+    def clear(self) -> None:
+        """Полностью очищает буфер и сбрасывает счётчики."""
+        with self._lock:
+            self._lines.clear()
+            self._dirty = False
+            self._evicted_count = 0
+
+    def __len__(self) -> int:
+        """Возвращает текущее количество строк в буфере."""
+        with self._lock:
+            return len(self._lines)
+
+    @property
+    def evicted_count(self) -> int:
+        """Суммарное число строк, вытесненных из буфера с момента создания.
+
+        Полезно для диагностики и тестирования burst-сценариев.
+        """
+        with self._lock:
+            return self._evicted_count

--- a/gui/views/api_settings_view.py
+++ b/gui/views/api_settings_view.py
@@ -26,6 +26,7 @@ from PyQt6.QtWidgets import (
 )
 
 from gui.accessibility import apply_accessible_metadata
+from gui.log_buffer import GuiLogBuffer
 from gui.styles.theme import Theme
 from logger_config import (
     get_api_log_dir,
@@ -36,7 +37,10 @@ from logger_config import (
 logger = get_module_logger(__name__)
 
 _LOG_REFRESH_INTERVAL_MS = 1000
-_MAX_LOG_BLOCKS = 5000
+# Максимум строк в QPlainTextEdit (жёсткое ограничение Qt-виджета).
+_MAX_LOG_BLOCKS = 2000
+# Максимум строк в in-memory ring-buffer (должен совпадать с виджетом).
+_RING_BUFFER_MAX_LINES = _MAX_LOG_BLOCKS
 _AUTO_REFRESH_PAUSED_TEXT = "Автообновление включится при открытии вкладки"
 _LOG_LOADING_TEXT = "Загрузка журнала API..."
 _LOG_EMPTY_TEXT = (
@@ -82,6 +86,9 @@ class ApiSettingsView(QWidget):
         self._server_running = False
         self._auto_refresh_enabled = False
         self._log_loaded_once = False
+        # Ring-buffer для хранения строк лога в памяти.
+        # Предотвращает неограниченный рост при burst-логировании.
+        self._log_buffer = GuiLogBuffer(max_lines=_RING_BUFFER_MAX_LINES)
 
         self.logs_load_completed.connect(self._on_logs_load_completed)
         self._setup_ui()
@@ -299,6 +306,19 @@ class ApiSettingsView(QWidget):
         """Периодическое обновление логов API."""
         self.refresh_logs()
 
+    def _flush_log_buffer_to_widget(self) -> None:
+        """Сбрасывает содержимое ring-buffer в QPlainTextEdit.
+
+        Вызывается только когда буфер помечен как dirty.  После
+        отрисовки dirty-флаг сбрасывается, чтобы избежать лишних
+        обновлений виджета.
+        """
+        if not self._log_buffer.is_dirty():
+            return
+        self._log_view.setPlainText(self._log_buffer.get_text())
+        self._log_buffer.clear_dirty()
+        self._scroll_logs_to_end()
+
     def _on_apply_clicked(self) -> None:
         """Обработка сохранения настроек."""
         self.apply_requested.emit(
@@ -414,27 +434,30 @@ class ApiSettingsView(QWidget):
         """
         Полная замена содержимого окна логов.
 
+        Данные помещаются в ring-buffer, который затем отрисовывается
+        виджетом при следующем тике таймера.
+
         Args:
             text: Текст логов.
         """
-        self._log_view.setPlainText(text)
-        self._scroll_logs_to_end()
+        self._log_buffer.clear()
+        self._log_buffer.append(text)
+        self._flush_log_buffer_to_widget()
 
     def append_log_text(self, text: str) -> None:
         """
-        Добавление текста в окно логов.
+        Добавление текста в ring-buffer логов.
+
+        Данные записываются в буфер немедленно, но виджет обновляется
+        только при наличии изменений (dirty-флаг) через таймер.
 
         Args:
             text: Текст для добавления.
         """
         if not text:
             return
-        cleaned_text = text.rstrip("\n")
-        if self._log_view.toPlainText():
-            self._log_view.appendPlainText(cleaned_text)
-        else:
-            self._log_view.setPlainText(cleaned_text)
-        self._scroll_logs_to_end()
+        self._log_buffer.append(text.rstrip("\n"))
+        self._flush_log_buffer_to_widget()
 
     def refresh_logs(self, show_loading_state: bool = False) -> None:
         """Обновление логов API из файла."""
@@ -626,7 +649,13 @@ class ApiSettingsView(QWidget):
         elif result.mode == "append":
             self.append_log_text(result.text)
 
-        self._set_log_status(result.status_message)
+        # Если накопились вытесненные строки — показать предупреждение
+        # в статусе, чтобы пользователь знал что буфер был переполнен.
+        evicted = self._log_buffer.evicted_count
+        status = result.status_message
+        if evicted:
+            status = f"{status} (вытеснено строк из буфера: {evicted})"
+        self._set_log_status(status)
 
     def _update_server_controls(self, running: bool) -> None:
         """Обновление состояния кнопок управления сервером."""
@@ -643,19 +672,25 @@ class ApiSettingsView(QWidget):
     def _show_loading_state(self) -> None:
         """Показать пользователю состояние загрузки журнала."""
         self._set_log_status(_LOG_LOADING_TEXT)
-        if not self._log_view.toPlainText():
-            self._log_view.setPlainText(_LOG_LOADING_TEXT)
+        if not self._log_buffer.get_text():
+            self._log_buffer.clear()
+            self._log_buffer.append(_LOG_LOADING_TEXT)
+            self._flush_log_buffer_to_widget()
 
     def _set_empty_state(self, message: str) -> None:
         """Показать состояние отсутствия данных."""
         self._log_loaded_once = True
-        self._log_view.setPlainText(message)
+        self._log_buffer.clear()
+        self._log_buffer.append(message)
+        self._flush_log_buffer_to_widget()
         self._set_log_status("Журнал API пуст или ещё не создан")
 
     def _set_error_state(self, message: str) -> None:
         """Показать состояние ошибки загрузки журнала."""
-        if not self._log_view.toPlainText():
-            self._log_view.setPlainText(message)
+        if not self._log_buffer.get_text():
+            self._log_buffer.clear()
+            self._log_buffer.append(message)
+            self._flush_log_buffer_to_widget()
         self._set_log_status(message, color="red")
 
     def _set_log_status(self, message: str, color: str = "gray") -> None:

--- a/tests/unit/gui/test_gui_log_buffer.py
+++ b/tests/unit/gui/test_gui_log_buffer.py
@@ -192,8 +192,7 @@ class TestGuiLogBufferThreadSafety:
                 errors.append(e)
 
         threads = [
-            threading.Thread(target=writer, args=(f"t{j}",))
-            for j in range(10)
+            threading.Thread(target=writer, args=(f"t{j}",)) for j in range(10)
         ]
         for t in threads:
             t.start()

--- a/tests/unit/gui/test_gui_log_buffer.py
+++ b/tests/unit/gui/test_gui_log_buffer.py
@@ -1,0 +1,235 @@
+"""Тесты для GuiLogBuffer — потокобезопасного кольцевого буфера логов."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from gui.log_buffer import GuiLogBuffer
+
+
+class TestGuiLogBufferInit:
+    """Тесты инициализации буфера."""
+
+    def test_default_values(self) -> None:
+        buf = GuiLogBuffer()
+        assert buf.max_lines == 2000
+        assert len(buf) == 0
+        assert buf.evicted_count == 0
+
+    def test_custom_max_lines(self) -> None:
+        buf = GuiLogBuffer(max_lines=100)
+        assert buf.max_lines == 100
+
+    def test_invalid_max_lines_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_lines"):
+            GuiLogBuffer(max_lines=0)
+
+    def test_invalid_max_line_length_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_line_length"):
+            GuiLogBuffer(max_lines=10, max_line_length=0)
+
+
+class TestGuiLogBufferAppend:
+    """Тесты добавления строк в буфер."""
+
+    def test_append_single_line(self) -> None:
+        buf = GuiLogBuffer(max_lines=10)
+        buf.append("line 1")
+        assert len(buf) == 1
+        assert buf.get_text() == "line 1"
+
+    def test_append_multiline_text(self) -> None:
+        buf = GuiLogBuffer(max_lines=10)
+        buf.append("line 1\nline 2\nline 3")
+        assert len(buf) == 3
+
+    def test_append_empty_string_noop(self) -> None:
+        buf = GuiLogBuffer(max_lines=10)
+        buf.append("")
+        assert len(buf) == 0
+        assert not buf.is_dirty()
+
+    def test_empty_lines_inside_text_ignored(self) -> None:
+        buf = GuiLogBuffer(max_lines=10)
+        buf.append("line 1\n\nline 2")
+        # Пустые строки пропускаются
+        assert len(buf) == 2
+
+    def test_long_line_truncated(self) -> None:
+        buf = GuiLogBuffer(max_lines=10, max_line_length=10)
+        buf.append("a" * 20)
+        text = buf.get_text()
+        assert len(text) <= 10
+        assert text.endswith("…")
+
+    def test_line_exactly_at_limit_not_truncated(self) -> None:
+        buf = GuiLogBuffer(max_lines=10, max_line_length=5)
+        buf.append("a" * 5)
+        assert buf.get_text() == "a" * 5
+
+
+class TestGuiLogBufferEviction:
+    """Тесты вытеснения старых строк (ring-buffer поведение)."""
+
+    def test_evicts_oldest_when_full(self) -> None:
+        buf = GuiLogBuffer(max_lines=3)
+        for i in range(5):
+            buf.append(f"line {i}")
+        # Должны остаться только последние 3
+        lines = buf.get_text().splitlines()
+        assert len(lines) == 3
+        assert lines[-1] == "line 4"
+        assert lines[-2] == "line 3"
+        assert lines[-3] == "line 2"
+
+    def test_evicted_count_tracks_overflow(self) -> None:
+        buf = GuiLogBuffer(max_lines=3)
+        for i in range(5):
+            buf.append(f"line {i}")
+        # 5 добавлено, лимит 3, вытеснено 2
+        assert buf.evicted_count == 2
+
+    def test_evicted_count_zero_when_no_overflow(self) -> None:
+        buf = GuiLogBuffer(max_lines=10)
+        buf.append("line 1\nline 2")
+        assert buf.evicted_count == 0
+
+    def test_evicted_count_accumulates(self) -> None:
+        buf = GuiLogBuffer(max_lines=2)
+        buf.append("a\nb\nc")  # Вытеснено 1 с первого батча
+        buf.append("d\ne\nf")  # Вытеснено ещё
+        assert buf.evicted_count > 0
+
+
+class TestGuiLogBufferDirtyFlag:
+    """Тесты dirty-флага для дебаунса UI."""
+
+    def test_initially_not_dirty(self) -> None:
+        buf = GuiLogBuffer()
+        assert not buf.is_dirty()
+
+    def test_dirty_after_append(self) -> None:
+        buf = GuiLogBuffer()
+        buf.append("line 1")
+        assert buf.is_dirty()
+
+    def test_clear_dirty_resets_flag(self) -> None:
+        buf = GuiLogBuffer()
+        buf.append("line 1")
+        buf.clear_dirty()
+        assert not buf.is_dirty()
+
+    def test_append_empty_does_not_set_dirty(self) -> None:
+        buf = GuiLogBuffer()
+        buf.append("")
+        assert not buf.is_dirty()
+
+    def test_dirty_again_after_new_append(self) -> None:
+        buf = GuiLogBuffer()
+        buf.append("line 1")
+        buf.clear_dirty()
+        buf.append("line 2")
+        assert buf.is_dirty()
+
+
+class TestGuiLogBufferClear:
+    """Тесты полной очистки буфера."""
+
+    def test_clear_empties_buffer(self) -> None:
+        buf = GuiLogBuffer(max_lines=10)
+        buf.append("line 1\nline 2")
+        buf.clear()
+        assert len(buf) == 0
+        assert buf.get_text() == ""
+
+    def test_clear_resets_dirty(self) -> None:
+        buf = GuiLogBuffer()
+        buf.append("line 1")
+        buf.clear()
+        assert not buf.is_dirty()
+
+    def test_clear_resets_evicted_count(self) -> None:
+        buf = GuiLogBuffer(max_lines=2)
+        buf.append("a\nb\nc")
+        buf.clear()
+        assert buf.evicted_count == 0
+
+
+class TestGuiLogBufferGetText:
+    """Тесты получения текста из буфера."""
+
+    def test_get_text_empty_buffer(self) -> None:
+        buf = GuiLogBuffer()
+        assert buf.get_text() == ""
+
+    def test_get_text_joins_lines(self) -> None:
+        buf = GuiLogBuffer(max_lines=10)
+        buf.append("line 1\nline 2\nline 3")
+        assert buf.get_text() == "line 1\nline 2\nline 3"
+
+    def test_get_text_does_not_reset_dirty(self) -> None:
+        buf = GuiLogBuffer()
+        buf.append("line 1")
+        _ = buf.get_text()
+        assert buf.is_dirty()
+
+
+class TestGuiLogBufferThreadSafety:
+    """Тесты потокобезопасности буфера."""
+
+    def test_concurrent_appends_no_data_race(self) -> None:
+        """Параллельные записи не должны приводить к данным гонки."""
+        buf = GuiLogBuffer(max_lines=1000)
+        errors: list[Exception] = []
+
+        def writer(prefix: str) -> None:
+            try:
+                for i in range(50):
+                    buf.append(f"{prefix}-{i}")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=writer, args=(f"t{j}",))
+            for j in range(10)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(buf) <= buf.max_lines
+
+    def test_concurrent_read_write_no_exception(self) -> None:
+        """Параллельные чтение и запись не должны вызывать исключений."""
+        buf = GuiLogBuffer(max_lines=100)
+        errors: list[Exception] = []
+
+        def writer() -> None:
+            try:
+                for i in range(30):
+                    buf.append(f"line {i}")
+            except Exception as e:
+                errors.append(e)
+
+        def reader() -> None:
+            try:
+                for _ in range(30):
+                    _ = buf.get_text()
+                    _ = buf.is_dirty()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=writer),
+            threading.Thread(target=reader),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors


### PR DESCRIPTION
## Описание

Реализует issue #126: потокобезопасный кольцевой буфер строк лога для GUI API-вкладки.

### Проблема
QPlainTextEdit в API-вкладке получал строки напрямую через ppendPlainText() без ограничений на размер.  При burst-логировании (например, интенсивная запись + API-запросы) виджет накапливал тысячи строк, вызывая:
- Неограниченный рост потребления памяти
- Замедление GUI при рендеринге тысяч блоков текста
- MAX_LOG_BLOCKS=5000 от Qt не полностью решал проблему — Qt оставляет строки в памяти

### Решение

**gui/log_buffer.py** — новый модуль GuiLogBuffer:
- deque(maxlen=max_lines) — автоматическое вытеснение старых строк
- 	hreading.Lock — полная потокобезопасность
- dirty-флаг — дебаунс: виджет обновляется только при наличии изменений
- victed_count — счётчик вытесненных строк для диагностики
- Обрезка строк длиннее max_line_length с суффиксом …

**gui/views/api_settings_view.py**:
- Все записи в лог-виджет маршрутизированы через GuiLogBuffer
- _flush_log_buffer_to_widget() — единая точка записи в QPlainTextEdit
- MAX_LOG_BLOCKS снижен 5000 → 2000 для синхронизации с буфером
- При burst-вытеснении статус показывает счётчик вытесненных строк

### Тесты
27 новых unit-тестов в 	ests/unit/gui/test_gui_log_buffer.py:
- инициализация с валидацией параметров
- append (одиночные/многострочные/пустые/длинные строки)
- eviction при переполнении (проверка FIFO-порядка)
- dirty-флаг (set/clear/повторный set)
- clear() — полный сброс
- thread safety (concurrent append + concurrent read/write)

### Результат
✅ 2267 passed, 78 skipped — все существующие тесты прошли

Closes #126