### PR TITLE
CI: добавить проверку покрытия тестами (coverage gate) и diff-coverage для PR (#120)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "tests\.local_tmp\pytest\coverage" | Out-Null
 
       - name: Run tests with coverage
-        run: uv run pytest tests/unit/ --basetemp=tests/.local_tmp/pytest/coverage --timeout=120 --cov=. --cov-report=xml --cov-report=json --cov-report=term-missing --cov-fail-under=60
+        run: uv run pytest tests/unit/ --basetemp=tests/.local_tmp/pytest/coverage --timeout=120 --cov=. --cov-report=xml --cov-report=json --cov-report=term-missing --cov-fail-under=70
 
       - name: Gate diff coverage for changed Python files
         run: |
@@ -166,7 +166,7 @@ jobs:
           if ("${{ github.event_name }}" -eq "pull_request") {
             $baseSha = "${{ github.event.pull_request.base.sha }}"
           }
-          uv run python scripts/check_diff_coverage.py --coverage-json coverage.json --base-sha $baseSha --head-sha "${{ github.sha }}" --min-file-coverage 35
+          uv run python scripts/check_diff_coverage.py --coverage-json coverage.json --base-sha $baseSha --head-sha "${{ github.sha }}" --min-file-coverage 60
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 *.py,cover
 .hypothesis/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [🇬🇧 English](README.md) · [🇷🇺 Русский](README.ru.md)
 
 [![CI](https://github.com/chelslava/MIA-ScreenCapture/actions/workflows/ci.yml/badge.svg)](https://github.com/chelslava/MIA-ScreenCapture/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/chelslava/MIA-ScreenCapture/branch/main/graph/badge.svg)](https://codecov.io/gh/chelslava/MIA-ScreenCapture)
 [![Version](https://img.shields.io/github/v/tag/chelslava/MIA-ScreenCapture?label=version&sort=semver)](https://github.com/chelslava/MIA-ScreenCapture/tags)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
 [![Platform](https://img.shields.io/badge/platform-Windows%2010%2F11-0078D6)](https://learn.microsoft.com/en-us/windows/win32/winrt/windows-graphics-capture)

--- a/README.ru.md
+++ b/README.ru.md
@@ -12,6 +12,7 @@
 [🇬🇧 English](README.md) · [🇷🇺 Русский](README.ru.md)
 
 [![CI](https://github.com/chelslava/MIA-ScreenCapture/actions/workflows/ci.yml/badge.svg)](https://github.com/chelslava/MIA-ScreenCapture/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/chelslava/MIA-ScreenCapture/branch/main/graph/badge.svg)](https://codecov.io/gh/chelslava/MIA-ScreenCapture)
 [![Version](https://img.shields.io/github/v/tag/chelslava/MIA-ScreenCapture?label=version&sort=semver)](https://github.com/chelslava/MIA-ScreenCapture/tags)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
 [![Platform](https://img.shields.io/badge/platform-Windows%2010%2F11-0078D6)](https://learn.microsoft.com/en-us/windows/win32/winrt/windows-graphics-capture)

--- a/scripts/check_diff_coverage.py
+++ b/scripts/check_diff_coverage.py
@@ -37,7 +37,11 @@ def _normalize_path(path: str) -> str:
 def _is_production_python_file(path: str) -> bool:
     """Возвращает True, если путь относится к production Python-коду."""
     normalized = _normalize_path(path)
-    if not normalized.endswith(".py"):
+    if (
+        not normalized.endswith(".py")
+        or normalized.endswith("/__init__.py")
+        or normalized == "__init__.py"
+    ):
         return False
     if normalized in PRODUCTION_SINGLE_FILES:
         return True
@@ -134,15 +138,14 @@ def _load_coverage_map(coverage_json_path: Path) -> dict[str, float]:
 
 def main() -> int:
     """Точка входа проверки diff coverage."""
-    import io
 
-    stdout_utf8 = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
-    stderr_utf8 = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
-
-    def safe_print(message: str, file: io.TextIOWrapper | None = None) -> None:
-        target = file or stdout_utf8
-        target.write(message + "\n")
-        target.flush()
+    def safe_print(message: str, file: object | None = None) -> None:
+        target = file or sys.stdout
+        try:
+            target.write(message + "\n")  # type: ignore[union-attr]
+            target.flush()  # type: ignore[union-attr]
+        except (AttributeError, UnicodeEncodeError):
+            print(message)
 
     parser = argparse.ArgumentParser(
         description="Проверка покрытия изменённых Python-файлов",
@@ -157,7 +160,7 @@ def main() -> int:
     parser.add_argument(
         "--min-file-coverage",
         type=float,
-        default=35.0,
+        default=60.0,
         help="Минимальное покрытие для изменённого файла (%)",
     )
     args = parser.parse_args()
@@ -166,7 +169,7 @@ def main() -> int:
     if not coverage_json_path.exists():
         safe_print(
             f"[diff-coverage] Файл не найден: {coverage_json_path}",
-            file=stderr_utf8,
+            file=sys.stderr,
         )
         return 2
 
@@ -174,7 +177,7 @@ def main() -> int:
         base_sha = _resolve_base_sha(args.base_sha, args.head_sha)
         changed_files = _get_changed_python_files(base_sha, args.head_sha)
     except RuntimeError as exc:
-        safe_print(f"[diff-coverage] {exc}", file=stderr_utf8)
+        safe_print(f"[diff-coverage] {exc}", file=sys.stderr)
         return 2
 
     if not changed_files:

--- a/tests/unit/scripts/test_check_diff_coverage.py
+++ b/tests/unit/scripts/test_check_diff_coverage.py
@@ -1,0 +1,286 @@
+"""Unit-тесты для scripts/check_diff_coverage.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.check_diff_coverage import (
+    _get_changed_python_files,
+    _is_production_python_file,
+    _load_coverage_map,
+    _normalize_path,
+    _resolve_base_sha,
+    main,
+)
+
+
+class TestNormalizePath:
+    """Тесты нормализации путей."""
+
+    def test_replaces_backslashes(self) -> None:
+        assert (
+            _normalize_path("gui\\views\\main_view.py")
+            == "gui/views/main_view.py"
+        )
+
+    def test_strips_leading_dot_slash(self) -> None:
+        assert _normalize_path("./core/profiles.py") == "core/profiles.py"
+        assert (
+            _normalize_path(".\\recorder\\video_recorder.py")
+            == "recorder/video_recorder.py"
+        )
+
+
+class TestIsProductionPythonFile:
+    """Тесты фильтрации production Python файлов."""
+
+    def test_matches_production_prefixes(self) -> None:
+        assert _is_production_python_file("api/routes.py") is True
+        assert _is_production_python_file("cli/parser.py") is True
+        assert _is_production_python_file("core/profiles.py") is True
+        assert _is_production_python_file("gui/main_window.py") is True
+        assert _is_production_python_file("recorder/encoder.py") is True
+        assert (
+            _is_production_python_file("scheduler/task_scheduler.py") is True
+        )
+
+    def test_matches_production_single_files(self) -> None:
+        assert _is_production_python_file("main.py") is True
+        assert _is_production_python_file("config.py") is True
+        assert _is_production_python_file("logger_config.py") is True
+        assert _is_production_python_file("exceptions.py") is True
+        assert _is_production_python_file("utils.py") is True
+
+    def test_ignores_non_python_and_test_files(self) -> None:
+        assert _is_production_python_file("README.md") is False
+        assert _is_production_python_file("tests/unit/test_config.py") is False
+        assert (
+            _is_production_python_file("scripts/check_diff_coverage.py")
+            is False
+        )
+        assert _is_production_python_file("pyproject.toml") is False
+        assert _is_production_python_file("gui/views/__init__.py") is False
+        assert _is_production_python_file("__init__.py") is False
+
+
+class TestResolveBaseSha:
+    """Тесты разрешения base SHA."""
+
+    def test_uses_provided_base_sha(self) -> None:
+        assert _resolve_base_sha("abc1234", "HEAD") == "abc1234"
+
+    def test_ignores_zero_sha_and_calls_git(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="fedcba9\n")
+            result = _resolve_base_sha(
+                "0000000000000000000000000000000000000000", "HEAD"
+            )
+            assert result == "fedcba9"
+            mock_run.assert_called_once_with(
+                ["git", "rev-parse", "HEAD~1"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+    def test_raises_when_git_fails(self) -> None:
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ):
+            with pytest.raises(
+                RuntimeError, match="Не удалось определить base SHA"
+            ):
+                _resolve_base_sha("", "HEAD")
+
+    def test_raises_when_git_returns_empty(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="  \n")
+            with pytest.raises(RuntimeError, match="Получен пустой base SHA"):
+                _resolve_base_sha("", "HEAD")
+
+
+class TestGetChangedPythonFiles:
+    """Тесты получения списка изменённых Python-файлов."""
+
+    def test_returns_filtered_production_files(self) -> None:
+        diff_output = "core/profiles.py\ntests/unit/test_profiles.py\nREADME.md\nmain.py\n"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=diff_output)
+            changed = _get_changed_python_files("base", "head")
+            assert changed == ["core/profiles.py", "main.py"]
+
+    def test_fallback_when_first_git_fails(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            # First diff fails, rev-parse succeeds, fallback diff succeeds
+            mock_run.side_effect = [
+                subprocess.CalledProcessError(1, "git diff"),
+                MagicMock(stdout="fallback_base\n"),
+                MagicMock(stdout="api/routes.py\n"),
+            ]
+            changed = _get_changed_python_files("invalid_base", "head")
+            assert changed == ["api/routes.py"]
+
+    def test_raises_when_fallback_also_fails(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CalledProcessError(1, "git diff"),
+                subprocess.CalledProcessError(1, "git rev-parse"),
+            ]
+            with pytest.raises(
+                RuntimeError, match="Не удалось получить список"
+            ):
+                _get_changed_python_files("invalid_base", "head")
+
+
+class TestLoadCoverageMap:
+    """Тесты загрузки coverage.json."""
+
+    def test_loads_percent_covered_map(self, tmp_path: Path) -> None:
+        cov_file = tmp_path / "coverage.json"
+        cov_file.write_text(
+            json.dumps(
+                {
+                    "files": {
+                        "core\\profiles.py": {
+                            "summary": {"percent_covered": 85.5}
+                        },
+                        "api/routes.py": {
+                            "summary": {"percent_covered": 92.0}
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        cov_map = _load_coverage_map(cov_file)
+        assert cov_map["core/profiles.py"] == 85.5
+        assert cov_map["api/routes.py"] == 92.0
+
+
+class TestMain:
+    """Тесты функции main."""
+
+    def test_returns_2_when_coverage_file_missing(
+        self, tmp_path: Path
+    ) -> None:
+        missing_file = str(tmp_path / "non_existent.json")
+        with patch(
+            "sys.argv",
+            ["check_diff_coverage.py", "--coverage-json", missing_file],
+        ):
+            assert main() == 2
+
+    def test_returns_2_when_base_sha_error(self, tmp_path: Path) -> None:
+        cov_file = tmp_path / "coverage.json"
+        cov_file.write_text("{}", encoding="utf-8")
+        with (
+            patch(
+                "sys.argv",
+                ["check_diff_coverage.py", "--coverage-json", str(cov_file)],
+            ),
+            patch(
+                "scripts.check_diff_coverage._resolve_base_sha",
+                side_effect=RuntimeError("base error"),
+            ),
+        ):
+            assert main() == 2
+
+    def test_returns_0_when_no_changed_files(self, tmp_path: Path) -> None:
+        cov_file = tmp_path / "coverage.json"
+        cov_file.write_text("{}", encoding="utf-8")
+        with (
+            patch(
+                "sys.argv",
+                ["check_diff_coverage.py", "--coverage-json", str(cov_file)],
+            ),
+            patch(
+                "scripts.check_diff_coverage._resolve_base_sha",
+                return_value="base",
+            ),
+            patch(
+                "scripts.check_diff_coverage._get_changed_python_files",
+                return_value=[],
+            ),
+        ):
+            assert main() == 0
+
+    def test_returns_0_when_all_files_pass_threshold(
+        self, tmp_path: Path
+    ) -> None:
+        cov_file = tmp_path / "coverage.json"
+        cov_file.write_text(
+            json.dumps(
+                {
+                    "files": {
+                        "core/profiles.py": {
+                            "summary": {"percent_covered": 75.0}
+                        },
+                        "main.py": {"summary": {"percent_covered": 65.0}},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "check_diff_coverage.py",
+                    "--coverage-json",
+                    str(cov_file),
+                    "--min-file-coverage",
+                    "60",
+                ],
+            ),
+            patch(
+                "scripts.check_diff_coverage._resolve_base_sha",
+                return_value="base",
+            ),
+            patch(
+                "scripts.check_diff_coverage._get_changed_python_files",
+                return_value=["core/profiles.py", "main.py"],
+            ),
+        ):
+            assert main() == 0
+
+    def test_returns_1_when_file_below_threshold(self, tmp_path: Path) -> None:
+        cov_file = tmp_path / "coverage.json"
+        cov_file.write_text(
+            json.dumps(
+                {
+                    "files": {
+                        "core/profiles.py": {
+                            "summary": {"percent_covered": 55.0}
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "check_diff_coverage.py",
+                    "--coverage-json",
+                    str(cov_file),
+                    "--min-file-coverage",
+                    "60",
+                ],
+            ),
+            patch(
+                "scripts.check_diff_coverage._resolve_base_sha",
+                return_value="base",
+            ),
+            patch(
+                "scripts.check_diff_coverage._get_changed_python_files",
+                return_value=["core/profiles.py"],
+            ),
+        ):
+            assert main() == 1


### PR DESCRIPTION
## Описание

Реализует issue #120: повышение требований к покрытию тестами в CI и отслеживание diff-coverage для входящих PR.

### Изменения:
1. **.github/workflows/ci.yml**:
   - Общий coverage gate повышен с 60% до 70% (--cov-fail-under=70).
   - Порог diff-coverage повышен с 35% до 60% (--min-file-coverage 60).
2. **scripts/check_diff_coverage.py**:
   - Значение параметра --min-file-coverage по умолчанию поднято до 60.0.
   - Исключены файлы __init__.py из списка production-файлов для diff-coverage, так как они исключены из подсчёта coverage.py.
   - Исправлен safe_print для предотвращения конфликтов с захватом дескрипторов pytest.
3. **tests/unit/scripts/test_check_diff_coverage.py**:
   - Добавлены 18 unit-тестов, полностью покрывающих функции скрипта diff-coverage.
4. **README.md, README.ru.md**:
   - Добавлен бейдж покрытия Codecov.
5. **.gitignore**:
   - Добавлен coverage.json.

Closes #120