### PR TITLE
Декомпозиция MainWindow: выделить модульные контроллеры (#115)

### DIFF
--- a/gui/controllers/desktop_actions_controller.py
+++ b/gui/controllers/desktop_actions_controller.py
@@ -1,0 +1,184 @@
+"""
+Контроллер desktop-действий, горячих клавиш и доступности (Accessibility)
+========================================================================
+
+Отвечает за:
+- регистрацию системных desktop-действий в едином реестре;
+- привязку горячих клавиш (QShortcut) и настройку порядка обхода табуляцией (Tab Order);
+- назначение метаданных доступности (AccessibleName, AccessibleDescription, Tooltip).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from PyQt6.QtWidgets import QWidget
+
+from gui.desktop_actions import (
+    DesktopAction,
+    DesktopActionId,
+    DesktopActionRegistry,
+    get_desktop_action_spec,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class DesktopActionsController:
+    """Контроллер управления desktop-действиями, shortcuts и доступностью."""
+
+    def __init__(
+        self,
+        registry: DesktopActionRegistry | None = None,
+    ) -> None:
+        self._registry = registry or DesktopActionRegistry()
+        self._registered_shortcuts: dict[str, str] = {}
+        self._qt_shortcuts: list[Any] = []
+        self._tab_navigation_order: list[QWidget] = []
+
+    @property
+    def registry(self) -> DesktopActionRegistry:
+        """Реестр зарегистрированных действий."""
+        return self._registry
+
+    @registry.setter
+    def registry(self, value: DesktopActionRegistry) -> None:
+        """Установить новый реестр действий."""
+        self._registry = value
+
+    @property
+    def registered_shortcuts(self) -> dict[str, str]:
+        """Словарь зарегистрированных горячих клавиш."""
+        return self._registered_shortcuts
+
+    @property
+    def tab_navigation_order(self) -> list[QWidget]:
+        """Список элементов в порядке обхода Tab."""
+        return self._tab_navigation_order
+
+    def register_default_actions(
+        self,
+        callbacks: dict[DesktopActionId, Callable[[], None]],
+        enabled_conditions: dict[DesktopActionId, Callable[[], bool]]
+        | None = None,
+    ) -> None:
+        """Регистрирует стандартный набор desktop-действий приложения."""
+        enabled_conditions = enabled_conditions or {}
+
+        for action_id, callback in callbacks.items():
+            spec = get_desktop_action_spec(action_id)
+            enabled_when = enabled_conditions.get(action_id)
+            self._registry.register(
+                DesktopAction(
+                    action_id=action_id,
+                    title=spec.title,
+                    description=spec.description,
+                    callback=callback,
+                    shortcut=spec.shortcut,
+                    enabled_when=enabled_when,
+                )
+            )
+
+    def apply_action_metadata(
+        self,
+        widget: QWidget,
+        action_id: DesktopActionId,
+    ) -> None:
+        """Применить tooltip/accessibility metadata для desktop-действия."""
+        action = self._registry.get(action_id)
+        tooltip = action.description
+        if action.shortcut:
+            tooltip = f"{tooltip} Горячая клавиша: {action.shortcut}."
+            self._registered_shortcuts[action_id.value] = action.shortcut
+
+        self.apply_accessible_metadata(
+            widget,
+            action.title,
+            action.description,
+        )
+
+        widget_any = cast(Any, widget)
+        widget_any._tooltip = tooltip
+        set_tooltip = getattr(widget, "setToolTip", None)
+        if callable(set_tooltip):
+            set_tooltip(tooltip)
+
+        set_shortcut = getattr(widget, "setShortcut", None)
+        if callable(set_shortcut) and action.shortcut:
+            set_shortcut(action.shortcut)
+        if action.shortcut:
+            widget_any._shortcut = action.shortcut
+
+    @staticmethod
+    def apply_accessible_metadata(
+        widget: QWidget,
+        accessible_name: str,
+        accessible_description: str,
+    ) -> None:
+        """Назначить accessible metadata с fallback для unit-test моков."""
+        widget_any = cast(Any, widget)
+        widget_any._accessible_name = accessible_name
+        widget_any._accessible_description = accessible_description
+        set_name = getattr(widget, "setAccessibleName", None)
+        if callable(set_name):
+            set_name(accessible_name)
+
+        set_description = getattr(widget, "setAccessibleDescription", None)
+        if callable(set_description):
+            set_description(accessible_description)
+
+    def configure_tab_order(
+        self,
+        parent: QWidget,
+        widgets: list[QWidget],
+    ) -> None:
+        """Настроить логичный tab order для элементов управления."""
+        self._tab_navigation_order = widgets
+        set_tab_order = getattr(parent, "setTabOrder", None)
+        if callable(set_tab_order):
+            for current_widget, next_widget in zip(
+                widgets,
+                widgets[1:],
+                strict=False,
+            ):
+                set_tab_order(current_widget, next_widget)
+
+    def register_qt_shortcuts(
+        self,
+        parent: QWidget,
+        alt_shortcuts: list[tuple[str, Any]] | None = None,
+    ) -> None:
+        """Зарегистрировать оконные shortcuts для действий и кнопок."""
+        self._qt_shortcuts.clear()
+        try:
+            from PyQt6.QtGui import QKeySequence, QShortcut
+        except Exception:
+            return
+
+        for action in self._registry.all():
+            if not action.shortcut:
+                continue
+            try:
+                shortcut = QShortcut(QKeySequence(action.shortcut), parent)
+                shortcut.activated.connect(
+                    lambda action_id=action.action_id: self._registry.execute(
+                        action_id
+                    )
+                )
+                self._qt_shortcuts.append(shortcut)
+            except Exception:
+                continue
+
+        if alt_shortcuts:
+            for key_seq, target in alt_shortcuts:
+                try:
+                    shortcut = QShortcut(QKeySequence(key_seq), parent)
+                    shortcut.activated.connect(
+                        lambda t=target: (
+                            t.click() if hasattr(t, "click") else t()
+                        )
+                    )
+                    self._qt_shortcuts.append(shortcut)
+                except Exception:
+                    continue

--- a/gui/controllers/profile_gui_controller.py
+++ b/gui/controllers/profile_gui_controller.py
@@ -1,0 +1,158 @@
+"""
+Контроллер управления профилями записи в GUI
+===========================================
+
+Отвечает за:
+- инициализацию и синхронизацию выпадающего списка профилей;
+- открытие диалога настройки профилей (ProfileDialog);
+- применение настроек выбранного профиля к представлениям захвата, аудио, видео и состоянию.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from core.profiles import get_profile_storage
+from core.recording_types import AudioMode, CaptureMode
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from PyQt6.QtWidgets import QComboBox, QStatusBar, QWidget
+
+    from gui.models.recording_state import RecordingState
+    from gui.views.audio_view import AudioView
+    from gui.views.capture_view import CaptureView
+    from gui.views.video_view import VideoView
+
+
+class ProfileGUIController:
+    """Контроллер интерфейса профилей записи."""
+
+    def __init__(self) -> None:
+        pass
+
+    def init_profiles(self, combo: QComboBox) -> None:
+        """Инициализация списка профилей в выпадающем списке."""
+        storage = get_profile_storage()
+        profiles = storage.list_profiles()
+
+        combo.blockSignals(True)
+        combo.clear()
+
+        default_index = 0
+        for i, profile in enumerate(profiles):
+            display_text = f"{profile.icon} {profile.name}"
+            combo.addItem(display_text, profile.id)
+            if profile.is_default:
+                default_index = i
+
+        if profiles:
+            combo.setCurrentIndex(default_index)
+
+        combo.blockSignals(False)
+
+    def on_profile_combo_changed(
+        self,
+        index: int,
+        combo: QComboBox,
+        apply_callback: Callable[[Any], None],
+    ) -> None:
+        """Обработка выбора профиля в выпадающем списке."""
+        if index < 0:
+            return
+
+        profile_id = combo.itemData(index)
+        if not profile_id:
+            return
+
+        storage = get_profile_storage()
+        profile = storage.get_profile(profile_id)
+        if profile:
+            apply_callback(profile)
+
+    def open_profile_dialog(
+        self,
+        parent: QWidget,
+        combo: QComboBox,
+        apply_callback: Callable[[Any], None],
+    ) -> None:
+        """Открытие диалога управления профилями."""
+        from gui.views.profile_dialog import ProfileDialog
+
+        def on_applied(profile_id: str) -> None:
+            storage = get_profile_storage()
+            profile = storage.get_profile(profile_id)
+            if profile:
+                apply_callback(profile)
+                self.init_profiles(combo)
+
+        dialog = ProfileDialog(parent=parent)
+        dialog.profiles_changed.connect(lambda: self.init_profiles(combo))
+        dialog.profile_applied.connect(on_applied)
+        dialog.exec()
+
+    def apply_profile_settings(
+        self,
+        profile: Any,
+        video_view: VideoView | None = None,
+        audio_view: AudioView | None = None,
+        capture_view: CaptureView | None = None,
+        state: RecordingState | None = None,
+        combo: QComboBox | None = None,
+        status_bar: QStatusBar | None = None,
+    ) -> None:
+        """Применяет параметры профиля к активным представлениям и состоянию."""
+        if hasattr(profile, "video") and video_view is not None:
+            v = profile.video
+            video_view.set_fps(v.fps)
+            video_view.set_codec(v.codec)
+            video_view.set_bitrate(v.bitrate)
+            video_view.set_format(v.format)
+            video_view.set_preset(v.preset)
+
+        if hasattr(profile, "audio"):
+            a = profile.audio
+            rec_mic = getattr(a, "record_mic", True)
+            rec_sys = getattr(a, "record_system", False)
+            if rec_mic and rec_sys:
+                audio_mode = AudioMode.BOTH
+            elif rec_mic:
+                audio_mode = AudioMode.MIC
+            elif rec_sys:
+                audio_mode = AudioMode.SYSTEM
+            else:
+                audio_mode = AudioMode.NONE
+
+            if state is not None:
+                state.set_audio_type(audio_mode)
+            if audio_view is not None:
+                audio_view.set_audio_type(audio_mode)
+
+        if hasattr(profile, "capture") and capture_view is not None:
+            c = profile.capture
+            area_type_str = getattr(c, "area_type", "full")
+            if area_type_str == "window":
+                mode = CaptureMode.WINDOW
+            elif area_type_str == "rect":
+                mode = CaptureMode.RECT
+            else:
+                mode = CaptureMode.FULL
+
+            capture_view.set_capture_type(mode)
+            if getattr(c, "window_title", None):
+                capture_view.set_window_title(c.window_title)
+            if getattr(c, "rect_coords", None):
+                capture_view.set_rect_coords(tuple(c.rect_coords))
+
+        if combo is not None:
+            combo.blockSignals(True)
+            for i in range(combo.count()):
+                if combo.itemData(i) == getattr(profile, "id", None):
+                    combo.setCurrentIndex(i)
+                    break
+            combo.blockSignals(False)
+
+        if status_bar is not None:
+            name = getattr(profile, "name", "Профиль")
+            status_bar.showMessage(f"Применен профиль: {name}", 4000)

--- a/gui/controllers/readiness_controller.py
+++ b/gui/controllers/readiness_controller.py
@@ -1,0 +1,169 @@
+"""
+Контроллер готовности системы к записи и диагностики
+===================================================
+
+Отвечает за:
+- асинхронную проверку зависимостей (FFmpeg, кодеки);
+- оценку параметров готовности (preflight readiness snapshot);
+- кэширование и разрешение результатов проверок готовности;
+- диспетчеризацию быстрых действий (one-click fixes) из readiness center.
+"""
+
+from __future__ import annotations
+
+import threading
+import webbrowser
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from core.readiness import (
+    ReadinessSnapshot,
+    RecordingReadinessService,
+)
+from gui.models.recording_state import AudioSettings, CaptureSettings
+from logger_config import get_module_logger
+from recorder.utils import FFmpegStatus, check_ffmpeg
+
+if TYPE_CHECKING:
+    pass
+
+logger = get_module_logger(__name__)
+
+
+class ReadinessController:
+    """Контроллер готовности к записи и проверки зависимостей."""
+
+    def __init__(
+        self,
+        readiness_service: RecordingReadinessService,
+        track_thread: Callable[[threading.Thread], threading.Thread]
+        | None = None,
+    ) -> None:
+        self._readiness_service = readiness_service
+        self._track_thread = track_thread or (lambda t: t)
+        self._readiness_request_id: int = 0
+        self._latest_readiness_snapshot: ReadinessSnapshot | None = None
+        self._latest_readiness_inputs: dict[str, Any] | None = None
+
+    @property
+    def latest_snapshot(self) -> ReadinessSnapshot | None:
+        """Последний полученный readiness snapshot."""
+        return self._latest_readiness_snapshot
+
+    @property
+    def latest_inputs(self) -> dict[str, Any] | None:
+        """Входные параметры последнего readiness snapshot."""
+        return self._latest_readiness_inputs
+
+    def check_dependencies(
+        self,
+        on_completed: Callable[[FFmpegStatus | None, str | None], None],
+    ) -> None:
+        """Запуск асинхронной проверки внешних зависимостей (FFmpeg)."""
+
+        def worker() -> None:
+            try:
+                result = check_ffmpeg()
+                on_completed(result, None)
+            except Exception as error:
+                on_completed(None, str(error))
+
+        t = threading.Thread(target=worker, daemon=True)
+        self._track_thread(t)
+        t.start()
+
+    def request_readiness_refresh(
+        self,
+        capture: CaptureSettings,
+        audio: AudioSettings,
+        output_path: Path,
+        on_completed: Callable[
+            [
+                int,
+                ReadinessSnapshot | None,
+                str | None,
+                CaptureSettings,
+                AudioSettings,
+            ],
+            None,
+        ],
+    ) -> int:
+        """Запуск фоновой оценки параметров готовности к записи."""
+        self._readiness_request_id += 1
+        request_id = self._readiness_request_id
+
+        def worker() -> None:
+            try:
+                snapshot = self._readiness_service.evaluate(
+                    capture=capture,
+                    audio=audio,
+                    output_path=output_path,
+                )
+                on_completed(request_id, snapshot, None, capture, audio)
+            except Exception as error:
+                on_completed(request_id, None, str(error), capture, audio)
+
+        t = threading.Thread(target=worker, daemon=True)
+        self._track_thread(t)
+        t.start()
+        return request_id
+
+    def is_request_current(self, request_id: int) -> bool:
+        """Проверяет, актуален ли ID запроса готовности."""
+        return request_id == self._readiness_request_id
+
+    def store_readiness_result(
+        self,
+        snapshot: ReadinessSnapshot,
+        capture: CaptureSettings,
+        audio: AudioSettings,
+        output_path: Path,
+    ) -> None:
+        """Сохраняет актуальный снимок готовности в кэш."""
+        self._latest_readiness_snapshot = snapshot
+        self._latest_readiness_inputs = {
+            "capture": capture,
+            "audio": audio,
+            "output_path": output_path,
+        }
+
+    def resolve_cached_snapshot(
+        self,
+        capture: CaptureSettings | None,
+        audio: AudioSettings,
+        output_path: Path,
+    ) -> ReadinessSnapshot | None:
+        """Возвращает закэшированный снимок готовности, если входные параметры совпадают."""
+        latest_inputs = self._latest_readiness_inputs
+        if latest_inputs is None or self._latest_readiness_snapshot is None:
+            return None
+
+        if (
+            latest_inputs.get("capture") == capture
+            and latest_inputs.get("audio") == audio
+            and latest_inputs.get("output_path") == output_path
+        ):
+            return self._latest_readiness_snapshot
+        return None
+
+    def handle_readiness_action(
+        self,
+        action_key: str,
+        action_handlers: dict[str, Callable[[], None]],
+    ) -> None:
+        """Выполнить быстрый переход/действие по исправлению проблемы готовности."""
+        if action_key == "open_ffmpeg_docs":
+            webbrowser.open("https://ffmpeg.org/download.html")
+            return
+
+        fallback_action_map = {
+            "Папка вывода": "choose_output_path",
+            "Аудиоустройства": "refresh_audio_devices",
+            "Окно захвата": "refresh_windows",
+            "FFmpeg": "open_ffmpeg_docs",
+        }
+        resolved_key = fallback_action_map.get(action_key, action_key)
+        handler = action_handlers.get(resolved_key)
+        if handler:
+            handler()

--- a/gui/controllers/recordings_controller.py
+++ b/gui/controllers/recordings_controller.py
@@ -1,0 +1,271 @@
+"""
+Контроллер управления списком недавних записей и миниатюрами
+============================================================
+
+Отвечает за:
+- отображение и фильтрацию списка недавних записей в GUI;
+- асинхронную генерацию и обновление миниатюр видеофайлов;
+- операции над файлами записей (открытие, показ в проводнике, удаление, копирование пути).
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtGui import QAction, QGuiApplication, QIcon
+from PyQt6.QtWidgets import (
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMenu,
+    QStatusBar,
+    QStyle,
+    QWidget,
+)
+
+from logger_config import get_module_logger, open_logs_folder
+from recorder.utils import format_filesize, generate_thumbnail
+
+if TYPE_CHECKING:
+    from gui.controllers.settings_controller import SettingsController
+    from gui.models.recording_state import RecordingState
+
+logger = get_module_logger(__name__)
+
+
+class RecordingsController:
+    """Контроллер управления историей записей и миниатюрами."""
+
+    def __init__(
+        self,
+        state: RecordingState,
+        settings_controller: SettingsController,
+        recordings_list: QListWidget,
+        filter_input: QLineEdit,
+        status_bar: QStatusBar | None = None,
+        track_thread: Callable[[threading.Thread], threading.Thread]
+        | None = None,
+    ) -> None:
+        self._state = state
+        self._settings_controller = settings_controller
+        self._recordings_list = recordings_list
+        self._filter_input = filter_input
+        self._status_bar = status_bar
+        self._track_thread = track_thread or (lambda t: t)
+
+    def refresh_recent_recordings(self) -> None:
+        """Обновление списка недавних записей с учётом фильтра."""
+        self._recordings_list.clear()
+        filter_text = self.normalized_recordings_filter()
+        for rec in self._state.recent_recordings:
+            if not rec.path.exists():
+                continue
+            if not self.recording_matches_filter(
+                rec.path.name, rec.date, filter_text
+            ):
+                continue
+            item_text = (
+                f"{rec.path.name} - {format_filesize(rec.size)} - {rec.date}"
+            )
+            item = QListWidgetItem(item_text)
+            item.setData(Qt.ItemDataRole.UserRole, str(rec.path))
+
+            thumbnail_path = generate_thumbnail(rec.path)
+            if thumbnail_path:
+                item.setIcon(QIcon(str(thumbnail_path)))
+            else:
+                item.setIcon(self.get_recorded_video_icon())
+
+            self._recordings_list.addItem(item)
+
+    def clear_recordings_filter(self) -> None:
+        """Сброс фильтра списка недавних записей."""
+        self._filter_input.setText("")
+        self.refresh_recent_recordings()
+
+    def normalized_recordings_filter(self) -> str:
+        """Нормализация текста фильтра для сравнения."""
+        return str(self._filter_input.text().strip().lower())
+
+    @staticmethod
+    def recording_matches_filter(
+        filename: str, date_text: str, filter_text: str
+    ) -> bool:
+        """Проверка попадания записи под фильтр."""
+        normalized_filter = filter_text.strip().lower()
+        if not normalized_filter:
+            return True
+        haystack = f"{filename.lower()} {date_text.lower()}"
+        return normalized_filter in haystack
+
+    def open_recording(self, item: QListWidgetItem) -> None:
+        """Открытие файла записи из элемента списка."""
+        path = item.data(Qt.ItemDataRole.UserRole)
+        if path:
+            self.open_file(str(path))
+
+    def open_selected_recording(self) -> None:
+        """Открытие выбранного файла записи."""
+        item = self._recordings_list.currentItem()
+        if item:
+            self.open_recording(item)
+
+    def open_latest_recording(self) -> None:
+        """Открытие самой свежей записи из списка."""
+        item = self._recordings_list.item(0)
+        if item:
+            self.open_recording(item)
+
+    def clear_recent_recordings(self) -> None:
+        """Очистка списка последних записей."""
+        self._settings_controller.clear_recent_recordings()
+        self.refresh_recent_recordings()
+        if self._status_bar is not None:
+            self._status_bar.showMessage(
+                "Список последних записей очищен", 5000
+            )
+
+    def open_recording_folder(self) -> None:
+        """Открытие папки с выбранной записью."""
+        item = self._recordings_list.currentItem()
+        if item:
+            path = Path(item.data(Qt.ItemDataRole.UserRole))
+            if path.parent.exists():
+                self.open_folder(str(path.parent))
+
+    def copy_selected_recording_path(self) -> None:
+        """Копирование пути выбранной записи в буфер обмена."""
+        item = self._recordings_list.currentItem()
+        if not item:
+            return
+        path = item.data(Qt.ItemDataRole.UserRole)
+        if not path:
+            return
+
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(str(path))
+        if self._status_bar is not None:
+            self._status_bar.showMessage(
+                "Путь записи скопирован в буфер обмена", 5000
+            )
+
+    def show_recordings_context_menu(
+        self, pos: Any, parent_widget: QWidget
+    ) -> None:
+        """Контекстное меню по правому клику на записи в списке."""
+        item = self._recordings_list.itemAt(pos)
+        if item is None:
+            return
+        self._recordings_list.setCurrentItem(item)
+
+        menu = QMenu(parent_widget)
+
+        open_action = QAction("Открыть файл", menu)
+        open_action.triggered.connect(self.open_selected_recording)
+        menu.addAction(open_action)
+
+        folder_action = QAction("Открыть папку", menu)
+        folder_action.triggered.connect(self.open_recording_folder)
+        menu.addAction(folder_action)
+
+        menu.addSeparator()
+
+        copy_action = QAction("Копировать путь", menu)
+        copy_action.triggered.connect(self.copy_selected_recording_path)
+        menu.addAction(copy_action)
+
+        menu.exec(self._recordings_list.mapToGlobal(pos))
+
+    def generate_thumbnail_for_recording(self, output_path: Path) -> None:
+        """Генерировать миниатюру для новой записи в фоновом потоке."""
+        t = threading.Thread(
+            target=self._generate_thumbnail_worker,
+            args=(output_path,),
+            daemon=True,
+        )
+        self._track_thread(t)
+        t.start()
+
+    def _generate_thumbnail_worker(self, output_path: Path) -> None:
+        """Фоновый worker для генерации миниатюры."""
+        thumbnail_path = generate_thumbnail(output_path)
+        if thumbnail_path:
+            QTimer.singleShot(
+                0,
+                lambda: self._update_thumbnail_icon(
+                    output_path, thumbnail_path
+                ),
+            )
+        else:
+            QTimer.singleShot(
+                0, lambda: self._update_thumbnail_icon(output_path, None)
+            )
+
+    def _update_thumbnail_icon(
+        self, output_path: Path, thumbnail_path: Path | None
+    ) -> None:
+        """Обновить иконку миниатюры для элемента списка записей."""
+        for i in range(self._recordings_list.count()):
+            item = self._recordings_list.item(i)
+            if item is None:
+                continue
+            item_path = item.data(Qt.ItemDataRole.UserRole)
+            if item_path is None:
+                continue
+            if Path(item_path) == output_path:
+                if thumbnail_path:
+                    item.setIcon(QIcon(str(thumbnail_path)))
+                else:
+                    item.setIcon(self.get_recorded_video_icon())
+                break
+
+    def get_recorded_video_icon(self) -> QIcon:
+        """Получить placeholder иконку для записи без миниатюры."""
+        style = self._recordings_list.style()
+        if style is not None:
+            return style.standardIcon(QStyle.StandardPixmap.SP_FileIcon)
+        return QIcon()
+
+    def open_file(self, path: str) -> None:
+        """Открытие файла с помощью системного приложения по умолчанию."""
+        system = platform.system()
+        if system == "Windows":
+            os.startfile(path)  # type: ignore[attr-defined, unused-ignore]
+        elif system == "Darwin":
+            subprocess.run(["open", path])
+        else:
+            subprocess.run(["xdg-open", path])
+
+    def open_folder(self, path: str) -> None:
+        """Открытие папки в файловом менеджере."""
+        system = platform.system()
+        if system == "Windows":
+            subprocess.run(["explorer", path])
+        elif system == "Darwin":
+            subprocess.run(["open", path])
+        else:
+            subprocess.run(["xdg-open", path])
+
+    def open_application_logs(
+        self, error_callback: Callable[[str], None] | None = None
+    ) -> None:
+        """Открыть папку логов приложения."""
+        try:
+            open_logs_folder()
+        except Exception as error:
+            logger.error("Не удалось открыть папку логов: %s", error)
+            if error_callback:
+                error_callback(f"Не удалось открыть папку логов: {error}")
+            return
+        if self._status_bar is not None:
+            self._status_bar.showMessage(
+                "Открыта папка логов приложения", 5000
+            )

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -10,7 +10,6 @@ import os
 import platform
 import subprocess
 import threading
-import webbrowser
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
@@ -44,7 +43,11 @@ from core.readiness import (
     build_readiness_checks,
 )
 from core.recording_types import AudioMode, CaptureMode
+from gui.controllers.desktop_actions_controller import DesktopActionsController
+from gui.controllers.profile_gui_controller import ProfileGUIController
+from gui.controllers.readiness_controller import ReadinessController
 from gui.controllers.recording_controller import RecordingController
+from gui.controllers.recordings_controller import RecordingsController
 from gui.controllers.settings_controller import SettingsController
 from gui.controllers.status_bar_controller import StatusBarController
 from gui.controllers.websocket_controller import WebSocketClientController
@@ -69,14 +72,12 @@ from gui.views.finalization_progress_dialog import (
     FinalizationProgressDialog,
 )
 from gui.views.output_view import OutputView
-from gui.views.profile_dialog import ProfileDialog
 from gui.views.readiness_center_view import ReadinessCenterView
 from gui.views.recording_indicator import RecordingIndicatorOverlay
 from gui.views.video_view import VideoView
 from logger_config import get_module_logger, open_logs_folder
 from recorder.utils import (
     FFmpegStatus,
-    check_ffmpeg,
     format_filesize,
     format_time,
     generate_thumbnail,
@@ -172,9 +173,21 @@ class MainWindow(QMainWindow):
             self._state, get_config()
         )
         self._readiness_service = RecordingReadinessService()
+        self._readiness_controller = ReadinessController(
+            self._readiness_service,
+            track_thread=self._thread_tracker.track,
+        )
         self._desktop_actions = DesktopActionRegistry()
-        self._registered_shortcuts: dict[str, str] = {}
-        self._tab_navigation_order: list[QWidget] = []
+        self._desktop_actions_controller = DesktopActionsController(
+            self._desktop_actions
+        )
+        self._registered_shortcuts = (
+            self._desktop_actions_controller.registered_shortcuts
+        )
+        self._tab_navigation_order = (
+            self._desktop_actions_controller.tab_navigation_order
+        )
+        self._profile_gui_controller = ProfileGUIController()
         self._ws_controller: WebSocketClientController | None = None
         self._recording_indicator = RecordingIndicatorOverlay()
         # Диалог прогресса финализации создаётся лениво,
@@ -191,6 +204,14 @@ class MainWindow(QMainWindow):
         # Настройка окна
         self._setup_window()
         self._setup_ui()
+        self._recordings_controller = RecordingsController(
+            state=self._state,
+            settings_controller=self._settings_controller,
+            recordings_list=self.recordings_list,
+            filter_input=self._recordings_filter_input,
+            status_bar=self.status_bar,
+            track_thread=self._thread_tracker.track,
+        )
         self._status_bar_controller = StatusBarController(
             start_btn=self.start_btn,
             stop_btn=self.stop_btn,
@@ -759,139 +780,114 @@ class MainWindow(QMainWindow):
 
     def _setup_desktop_actions(self) -> None:
         """Создать action registry, shortcuts и accessibility metadata."""
-        start_spec = get_desktop_action_spec(DesktopActionId.START_RECORDING)
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.START_RECORDING,
-                title=start_spec.title,
-                description=start_spec.description,
-                callback=self._start_recording,
-                shortcut=start_spec.shortcut,
-                enabled_when=lambda: not self._state.is_recording(),
+        callbacks = {
+            DesktopActionId.START_RECORDING: self._start_recording,
+            DesktopActionId.TOGGLE_PAUSE: self._toggle_pause,
+            DesktopActionId.STOP_RECORDING: self._stop_recording,
+            DesktopActionId.OPEN_LATEST_RECORDING: self._open_latest_recording,
+            DesktopActionId.OPEN_RECORDING_FOLDER: self._open_recording_folder,
+            DesktopActionId.SHOW_RECORDING_TAB: lambda: (
+                self._sidebar.setCurrentRow(0)
+                if hasattr(self, "_sidebar")
+                else None
+            ),
+            DesktopActionId.SHOW_SCHEDULER_TAB: lambda: (
+                self._sidebar.setCurrentRow(2)
+                if hasattr(self, "_sidebar")
+                else None
+            ),
+            DesktopActionId.SHOW_DIAGNOSTICS_TAB: lambda: (
+                self._sidebar.setCurrentRow(3)
+                if hasattr(self, "_sidebar")
+                else None
+            ),
+            DesktopActionId.SHOW_API_TAB: lambda: (
+                self._sidebar.setCurrentRow(4)
+                if hasattr(self, "_sidebar")
+                else None
+            ),
+            DesktopActionId.OPEN_APP_LOGS: self._open_application_logs,
+        }
+        enabled_conditions = {
+            DesktopActionId.START_RECORDING: lambda: (
+                not self._state.is_recording()
+            ),
+            DesktopActionId.TOGGLE_PAUSE: lambda: (
+                self._state.is_recording() or self._state.is_paused()
+            ),
+            DesktopActionId.STOP_RECORDING: lambda: (
+                self._state.is_recording() or self._state.is_paused()
+            ),
+        }
+        if hasattr(self, "_desktop_actions_controller"):
+            self._desktop_actions_controller.registry = self._desktop_actions
+            self._desktop_actions_controller.register_default_actions(
+                callbacks=callbacks,
+                enabled_conditions=enabled_conditions,
             )
-        )
-        pause_spec = get_desktop_action_spec(DesktopActionId.TOGGLE_PAUSE)
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.TOGGLE_PAUSE,
-                title=pause_spec.title,
-                description=pause_spec.description,
-                callback=self._toggle_pause,
-                shortcut=pause_spec.shortcut,
-                enabled_when=lambda: (
-                    self._state.is_recording() or self._state.is_paused()
+        else:
+            for action_id, spec in [
+                (
+                    DesktopActionId.START_RECORDING,
+                    get_desktop_action_spec(DesktopActionId.START_RECORDING),
                 ),
-            )
-        )
-        stop_spec = get_desktop_action_spec(DesktopActionId.STOP_RECORDING)
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.STOP_RECORDING,
-                title=stop_spec.title,
-                description=stop_spec.description,
-                callback=self._stop_recording,
-                shortcut=stop_spec.shortcut,
-                enabled_when=lambda: (
-                    self._state.is_recording() or self._state.is_paused()
+                (
+                    DesktopActionId.TOGGLE_PAUSE,
+                    get_desktop_action_spec(DesktopActionId.TOGGLE_PAUSE),
                 ),
-            )
-        )
-        latest_spec = get_desktop_action_spec(
-            DesktopActionId.OPEN_LATEST_RECORDING
-        )
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.OPEN_LATEST_RECORDING,
-                title=latest_spec.title,
-                description=latest_spec.description,
-                callback=self._open_latest_recording,
-                shortcut=latest_spec.shortcut,
-            )
-        )
-        folder_spec = get_desktop_action_spec(
-            DesktopActionId.OPEN_RECORDING_FOLDER
-        )
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.OPEN_RECORDING_FOLDER,
-                title=folder_spec.title,
-                description=folder_spec.description,
-                callback=self._open_recording_folder,
-                shortcut=folder_spec.shortcut,
-            )
-        )
-        recording_tab_spec = get_desktop_action_spec(
-            DesktopActionId.SHOW_RECORDING_TAB
-        )
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.SHOW_RECORDING_TAB,
-                title=recording_tab_spec.title,
-                description=recording_tab_spec.description,
-                callback=lambda: (
-                    self._sidebar.setCurrentRow(0)
-                    if hasattr(self, "_sidebar")
-                    else None
+                (
+                    DesktopActionId.STOP_RECORDING,
+                    get_desktop_action_spec(DesktopActionId.STOP_RECORDING),
                 ),
-                shortcut=recording_tab_spec.shortcut,
-            )
-        )
-        scheduler_tab_spec = get_desktop_action_spec(
-            DesktopActionId.SHOW_SCHEDULER_TAB
-        )
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.SHOW_SCHEDULER_TAB,
-                title=scheduler_tab_spec.title,
-                description=scheduler_tab_spec.description,
-                callback=lambda: (
-                    self._sidebar.setCurrentRow(2)
-                    if hasattr(self, "_sidebar")
-                    else None
+                (
+                    DesktopActionId.OPEN_LATEST_RECORDING,
+                    get_desktop_action_spec(
+                        DesktopActionId.OPEN_LATEST_RECORDING
+                    ),
                 ),
-                shortcut=scheduler_tab_spec.shortcut,
-            )
-        )
-        diagnostics_tab_spec = get_desktop_action_spec(
-            DesktopActionId.SHOW_DIAGNOSTICS_TAB
-        )
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.SHOW_DIAGNOSTICS_TAB,
-                title=diagnostics_tab_spec.title,
-                description=diagnostics_tab_spec.description,
-                callback=lambda: (
-                    self._sidebar.setCurrentRow(3)
-                    if hasattr(self, "_sidebar")
-                    else None
+                (
+                    DesktopActionId.OPEN_RECORDING_FOLDER,
+                    get_desktop_action_spec(
+                        DesktopActionId.OPEN_RECORDING_FOLDER
+                    ),
                 ),
-                shortcut=diagnostics_tab_spec.shortcut,
-            )
-        )
-        api_tab_spec = get_desktop_action_spec(DesktopActionId.SHOW_API_TAB)
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.SHOW_API_TAB,
-                title=api_tab_spec.title,
-                description=api_tab_spec.description,
-                callback=lambda: (
-                    self._sidebar.setCurrentRow(4)
-                    if hasattr(self, "_sidebar")
-                    else None
+                (
+                    DesktopActionId.SHOW_RECORDING_TAB,
+                    get_desktop_action_spec(
+                        DesktopActionId.SHOW_RECORDING_TAB
+                    ),
                 ),
-                shortcut=api_tab_spec.shortcut,
-            )
-        )
-        app_logs_spec = get_desktop_action_spec(DesktopActionId.OPEN_APP_LOGS)
-        self._desktop_actions.register(
-            DesktopAction(
-                action_id=DesktopActionId.OPEN_APP_LOGS,
-                title=app_logs_spec.title,
-                description=app_logs_spec.description,
-                callback=self._open_application_logs,
-                shortcut=app_logs_spec.shortcut,
-            )
-        )
+                (
+                    DesktopActionId.SHOW_SCHEDULER_TAB,
+                    get_desktop_action_spec(
+                        DesktopActionId.SHOW_SCHEDULER_TAB
+                    ),
+                ),
+                (
+                    DesktopActionId.SHOW_DIAGNOSTICS_TAB,
+                    get_desktop_action_spec(
+                        DesktopActionId.SHOW_DIAGNOSTICS_TAB
+                    ),
+                ),
+                (
+                    DesktopActionId.SHOW_API_TAB,
+                    get_desktop_action_spec(DesktopActionId.SHOW_API_TAB),
+                ),
+                (
+                    DesktopActionId.OPEN_APP_LOGS,
+                    get_desktop_action_spec(DesktopActionId.OPEN_APP_LOGS),
+                ),
+            ]:
+                self._desktop_actions.register(
+                    DesktopAction(
+                        action_id=action_id,
+                        title=spec.title,
+                        description=spec.description,
+                        callback=callbacks[action_id],
+                        shortcut=spec.shortcut,
+                        enabled_when=enabled_conditions.get(action_id),
+                    )
+                )
 
         self._apply_action_metadata(
             self.start_btn,
@@ -985,16 +981,9 @@ class MainWindow(QMainWindow):
         accessible_description: str,
     ) -> None:
         """Назначить accessible metadata с fallback для unit-test моков."""
-        widget_any = cast(Any, widget)
-        widget_any._accessible_name = accessible_name
-        widget_any._accessible_description = accessible_description
-        set_name = getattr(widget, "setAccessibleName", None)
-        if callable(set_name):
-            set_name(accessible_name)
-
-        set_description = getattr(widget, "setAccessibleDescription", None)
-        if callable(set_description):
-            set_description(accessible_description)
+        DesktopActionsController.apply_accessible_metadata(
+            widget, accessible_name, accessible_description
+        )
 
     def _configure_tab_order(self) -> None:
         """Настроить логичный tab order для сценариев без мыши."""
@@ -1008,50 +997,31 @@ class MainWindow(QMainWindow):
             self._open_folder_btn,
         ]
         self._tab_navigation_order = tab_order
-        set_tab_order = getattr(self, "setTabOrder", None)
-        if callable(set_tab_order):
-            for current_widget, next_widget in zip(
-                tab_order,
-                tab_order[1:],
-                strict=False,
-            ):
-                set_tab_order(current_widget, next_widget)
+        if hasattr(self, "_desktop_actions_controller"):
+            self._desktop_actions_controller.configure_tab_order(
+                self, tab_order
+            )
+        else:
+            set_tab_order = getattr(self, "setTabOrder", None)
+            if callable(set_tab_order):
+                for current_widget, next_widget in zip(
+                    tab_order,
+                    tab_order[1:],
+                    strict=False,
+                ):
+                    set_tab_order(current_widget, next_widget)
 
     def _register_qt_shortcuts(self) -> None:
         """Зарегистрировать оконные shortcuts для key actions."""
-        self._qt_shortcuts: list[Any] = []
-        try:
-            from PyQt6.QtGui import QKeySequence, QShortcut
-        except Exception:
-            return
-
-        for action in self._desktop_actions.all():
-            if not action.shortcut:
-                continue
-            try:
-                shortcut = QShortcut(QKeySequence(action.shortcut), self)
-                shortcut.activated.connect(
-                    lambda action_id=action.action_id: (
-                        self._desktop_actions.execute(action_id)
-                    )
-                )
-                self._qt_shortcuts.append(shortcut)
-            except Exception:
-                continue
-
-        # Дополнительные Alt-shortcuts для доступности без мыши
-        _alt_shortcuts: list[tuple[str, Any]] = [
+        alt_shortcuts: list[tuple[str, Any]] = [
             ("Alt+R", self.start_btn),
             ("Alt+S", self.stop_btn),
             ("Alt+P", self.pause_btn),
         ]
-        for key_seq, btn in _alt_shortcuts:
-            try:
-                shortcut = QShortcut(QKeySequence(key_seq), self)
-                shortcut.activated.connect(lambda b=btn: b.click())
-                self._qt_shortcuts.append(shortcut)
-            except Exception:
-                continue
+        if hasattr(self, "_desktop_actions_controller"):
+            self._desktop_actions_controller.register_qt_shortcuts(
+                self, alt_shortcuts
+            )
 
     def _apply_settings_to_views(self) -> None:
         """Применение настроек к представлениям."""
@@ -1113,13 +1083,10 @@ class MainWindow(QMainWindow):
             item = QListWidgetItem(item_text)
             item.setData(Qt.ItemDataRole.UserRole, str(rec.path))
 
-            # Попытаться загрузить существующую миниатюру
-            # (единый центральный кэш, #103)
             thumbnail_path = generate_thumbnail(rec.path)
             if thumbnail_path:
                 item.setIcon(QIcon(str(thumbnail_path)))
             else:
-                # Показать placeholder если миниатюра не создана
                 item.setIcon(self._get_recorded_video_icon())
 
             self.recordings_list.addItem(item)
@@ -1131,18 +1098,16 @@ class MainWindow(QMainWindow):
 
     def _normalized_recordings_filter(self) -> str:
         """Нормализация текста фильтра для сравнения."""
-        return str(self._recordings_filter_input.text().strip().lower())
+        return self._recordings_controller.normalized_recordings_filter()
 
     @staticmethod
     def _recording_matches_filter(
         filename: str, date_text: str, filter_text: str
     ) -> bool:
         """Проверка попадания записи под фильтр."""
-        normalized_filter = filter_text.strip().lower()
-        if not normalized_filter:
-            return True
-        haystack = f"{filename.lower()} {date_text.lower()}"
-        return normalized_filter in haystack
+        return RecordingsController.recording_matches_filter(
+            filename, date_text, filter_text
+        )
 
     # === Обработчики сигналов от представлений ===
 
@@ -1231,47 +1196,20 @@ class MainWindow(QMainWindow):
 
         audio = self._build_audio_settings_from_state()
         output_path = self._settings_controller.get_output_path()
-        self._readiness_request_id += 1
-        request_id = self._readiness_request_id
         self._readiness_center_view.set_loading_state()
 
-        t = threading.Thread(
-            target=self._refresh_readiness_worker,
-            args=(request_id, capture, audio, output_path),
-            daemon=True,
-        )
-        self._thread_tracker.track(t)
-        t.start()
-
-    def _refresh_readiness_worker(
-        self,
-        request_id: int,
-        capture: CaptureSettings,
-        audio: AudioSettings,
-        output_path: Path,
-    ) -> None:
-        """Собрать readiness snapshot в фоне для inline summary."""
-        try:
-            snapshot = self._readiness_service.evaluate(
+        self._readiness_request_id = (
+            self._readiness_controller.request_readiness_refresh(
                 capture=capture,
                 audio=audio,
                 output_path=output_path,
+                on_completed=lambda req_id, snap, err, cap, aud: (
+                    self.readiness_refresh_completed.emit(
+                        req_id, snap, err, cap, aud
+                    )
+                ),
             )
-            self.readiness_refresh_completed.emit(
-                request_id,
-                snapshot,
-                None,
-                capture,
-                audio,
-            )
-        except Exception as error:
-            self.readiness_refresh_completed.emit(
-                request_id,
-                None,
-                str(error),
-                capture,
-                audio,
-            )
+        )
 
     def _on_readiness_refresh_completed(
         self,
@@ -1282,7 +1220,7 @@ class MainWindow(QMainWindow):
         audio: object,
     ) -> None:
         """Применить readiness snapshot к compact center."""
-        if request_id != self._readiness_request_id:
+        if not self._readiness_controller.is_request_current(request_id):
             return
 
         if error is not None:
@@ -1299,12 +1237,18 @@ class MainWindow(QMainWindow):
             return
 
         checks = build_readiness_checks(snapshot, capture, audio)
-        self._latest_readiness_snapshot = snapshot
-        self._latest_readiness_inputs = {
-            "capture": capture,
-            "audio": audio,
-            "output_path": self._settings_controller.get_output_path(),
-        }
+        self._readiness_controller.store_readiness_result(
+            snapshot,
+            capture,
+            audio,
+            self._settings_controller.get_output_path(),
+        )
+        self._latest_readiness_snapshot = (
+            self._readiness_controller.latest_snapshot
+        )
+        self._latest_readiness_inputs = (
+            self._readiness_controller.latest_inputs
+        )
         self._readiness_center_view.apply_checks(checks)
 
     def _show_readiness_details(self) -> None:
@@ -1375,55 +1319,45 @@ class MainWindow(QMainWindow):
 
     def _handle_readiness_action(self, action_key: str) -> None:
         """Выполнить one-click action из readiness center или диагностики."""
-        if action_key == "open_ffmpeg_docs":
-            webbrowser.open("https://ffmpeg.org/download.html")
-            return
 
-        if action_key == "choose_output_path":
-            self._select_output_folder()
-            return
-
-        if action_key == "refresh_windows":
+        def _refresh_windows_action() -> None:
             if hasattr(self, "_sidebar"):
                 self._sidebar.setCurrentRow(0)
             self._capture_view.refresh_windows()
-            return
 
-        if action_key == "focus_capture_window":
+        def _focus_capture_window_action() -> None:
             if hasattr(self, "_sidebar"):
                 self._sidebar.setCurrentRow(0)
             self._capture_view.set_capture_type(CaptureMode.WINDOW)
             self._capture_view.focus_window_combo()
-            return
 
-        if action_key == "refresh_audio_devices":
+        def _refresh_audio_devices_action() -> None:
             if hasattr(self, "_sidebar"):
                 self._sidebar.setCurrentRow(1)
             self._audio_view._refresh_audio_devices()
-            return
 
-        if action_key == "focus_microphone_selection":
+        def _focus_microphone_selection_action() -> None:
             if hasattr(self, "_sidebar"):
                 self._sidebar.setCurrentRow(1)
             focus = getattr(self._audio_view._mic_combo, "setFocus", None)
             if callable(focus):
                 focus()
-            return
 
-        if action_key == "API сервер":
+        def _switch_to_api_tab() -> None:
             if hasattr(self, "_sidebar"):
                 self._sidebar.setCurrentRow(4)
-            return
 
-        fallback_action_map = {
-            "Папка вывода": "choose_output_path",
-            "Аудиоустройства": "refresh_audio_devices",
-            "Окно захвата": "refresh_windows",
-            "FFmpeg": "open_ffmpeg_docs",
+        handlers: dict[str, Callable[[], None]] = {
+            "choose_output_path": self._select_output_folder,
+            "refresh_windows": _refresh_windows_action,
+            "focus_capture_window": _focus_capture_window_action,
+            "refresh_audio_devices": _refresh_audio_devices_action,
+            "focus_microphone_selection": _focus_microphone_selection_action,
+            "API сервер": _switch_to_api_tab,
         }
-        resolved_action = fallback_action_map.get(action_key)
-        if resolved_action is not None:
-            self._handle_readiness_action(resolved_action)
+        self._readiness_controller.handle_readiness_action(
+            action_key, handlers
+        )
 
     # === Управление профилями записи ===
 
@@ -1431,116 +1365,34 @@ class MainWindow(QMainWindow):
         """Инициализация списка профилей в выпадающем списке."""
         if not hasattr(self, "_profile_combo"):
             return
-
-        from core.profiles import get_profile_storage
-
-        storage = get_profile_storage()
-        profiles = storage.list_profiles()
-
-        self._profile_combo.blockSignals(True)
-        self._profile_combo.clear()
-
-        default_index = 0
-        for i, profile in enumerate(profiles):
-            display_text = f"{profile.icon} {profile.name}"
-            self._profile_combo.addItem(display_text, profile.id)
-            if profile.is_default:
-                default_index = i
-
-        if profiles:
-            self._profile_combo.setCurrentIndex(default_index)
-
-        self._profile_combo.blockSignals(False)
+        self._profile_gui_controller.init_profiles(self._profile_combo)
 
     def _on_profile_combo_changed(self, index: int) -> None:
         """Обработка выбора профиля в выпадающем списке."""
         if index < 0 or not hasattr(self, "_profile_combo"):
             return
-
-        profile_id = self._profile_combo.itemData(index)
-        if not profile_id:
-            return
-
-        from core.profiles import get_profile_storage
-
-        storage = get_profile_storage()
-        profile = storage.get_profile(profile_id)
-        if profile:
-            self.apply_profile_settings(profile)
+        self._profile_gui_controller.on_profile_combo_changed(
+            index, self._profile_combo, self.apply_profile_settings
+        )
 
     def _open_profile_dialog(self) -> None:
         """Открытие диалога управления профилями."""
-        dialog = ProfileDialog(parent=self)
-        dialog.profiles_changed.connect(self._init_profiles)
-        dialog.profile_applied.connect(self._on_profile_applied_from_dialog)
-        dialog.exec()
-
-    def _on_profile_applied_from_dialog(self, profile_id: str) -> None:
-        """Обработка применения профиля из диалога."""
-        from core.profiles import get_profile_storage
-
-        storage = get_profile_storage()
-        profile = storage.get_profile(profile_id)
-        if profile:
-            self.apply_profile_settings(profile)
-            self._init_profiles()
+        if hasattr(self, "_profile_combo"):
+            self._profile_gui_controller.open_profile_dialog(
+                self, self._profile_combo, self.apply_profile_settings
+            )
 
     def apply_profile_settings(self, profile: Any) -> None:
         """Применяет параметры профиля к активным представлениям и состоянию."""
-        if hasattr(profile, "video") and hasattr(self, "_video_view"):
-            v = profile.video
-            self._video_view.set_fps(v.fps)
-            self._video_view.set_codec(v.codec)
-            self._video_view.set_bitrate(v.bitrate)
-            self._video_view.set_format(v.format)
-            self._video_view.set_preset(v.preset)
-
-        if hasattr(profile, "audio"):
-            a = profile.audio
-            rec_mic = getattr(a, "record_mic", True)
-            rec_sys = getattr(a, "record_system", False)
-            if rec_mic and rec_sys:
-                audio_mode = AudioMode.BOTH
-            elif rec_mic:
-                audio_mode = AudioMode.MIC
-            elif rec_sys:
-                audio_mode = AudioMode.SYSTEM
-            else:
-                audio_mode = AudioMode.NONE
-
-            self._state.set_audio_type(audio_mode)
-            if hasattr(self, "_audio_view"):
-                self._audio_view.set_audio_type(audio_mode)
-
-        if hasattr(profile, "capture") and hasattr(self, "_capture_view"):
-            c = profile.capture
-            area_type_str = getattr(c, "area_type", "full")
-            if area_type_str == "window":
-                mode = CaptureMode.WINDOW
-            elif area_type_str == "rect":
-                mode = CaptureMode.RECT
-            else:
-                mode = CaptureMode.FULL
-
-            self._capture_view.set_capture_type(mode)
-            if getattr(c, "window_title", None):
-                self._capture_view.set_window_title(c.window_title)
-            if getattr(c, "rect_coords", None):
-                self._capture_view.set_rect_coords(tuple(c.rect_coords))
-
-        if hasattr(self, "_profile_combo"):
-            self._profile_combo.blockSignals(True)
-            for i in range(self._profile_combo.count()):
-                if self._profile_combo.itemData(i) == getattr(
-                    profile, "id", None
-                ):
-                    self._profile_combo.setCurrentIndex(i)
-                    break
-            self._profile_combo.blockSignals(False)
-
-        if hasattr(self, "status_bar"):
-            name = getattr(profile, "name", "Профиль")
-            self.status_bar.showMessage(f"Применен профиль: {name}", 4000)
+        self._profile_gui_controller.apply_profile_settings(
+            profile,
+            video_view=getattr(self, "_video_view", None),
+            audio_view=getattr(self, "_audio_view", None),
+            capture_view=getattr(self, "_capture_view", None),
+            state=getattr(self, "_state", None),
+            combo=getattr(self, "_profile_combo", None),
+            status_bar=getattr(self, "status_bar", None),
+        )
 
     # === Управление записью ===
 
@@ -1851,85 +1703,14 @@ class MainWindow(QMainWindow):
         logger.info(f"Запись остановлена: {output_path}")
 
     def _generate_thumbnail_for_recording(self, output_path: Path) -> None:
-        """
-        Генерировать миниатюру для новой записи в фоновом потоке.
-
-        Args:
-            output_path: Путь к записи, для которой нужно сгенерировать миниатюру.
-        """
-        t = threading.Thread(
-            target=self._generate_thumbnail_worker,
-            args=(output_path,),
-            daemon=True,
+        """Генерировать миниатюру для новой записи в фоновом потоке."""
+        self._recordings_controller.generate_thumbnail_for_recording(
+            output_path
         )
-        self._thread_tracker.track(t)
-        t.start()
-
-    def _generate_thumbnail_worker(self, output_path: Path) -> None:
-        """
-        Фоновый worker для генерации миниатюры.
-
-        Args:
-            output_path: Путь к записи.
-        """
-        # Единый центральный кэш миниатюр, #103
-        thumbnail_path = generate_thumbnail(output_path)
-
-        # Обновить UI в главном потоке через сигнал
-        if thumbnail_path:
-            # Запустить второй поток для обновления UI
-            QTimer.singleShot(
-                0,
-                lambda: self._update_thumbnail_icon(
-                    output_path, thumbnail_path
-                ),
-            )
-        else:
-            # Показать placeholder если миниатюра не создана
-            QTimer.singleShot(
-                0, lambda: self._update_thumbnail_icon(output_path, None)
-            )
-
-    def _update_thumbnail_icon(
-        self, output_path: Path, thumbnail_path: Path | None
-    ) -> None:
-        """
-        Обновить иконку миниатюры для элемента списка записей.
-
-        Args:
-            output_path: Путь к записи.
-            thumbnail_path: Путь к миниатюре, или None если миниатюра не создана.
-        """
-        for i in range(self.recordings_list.count()):
-            item = self.recordings_list.item(i)
-            if item is None:
-                continue
-            item_path = item.data(Qt.ItemDataRole.UserRole)
-            if item_path is None:
-                continue
-            if Path(item_path) == output_path:
-                if thumbnail_path:
-                    item.setIcon(QIcon(str(thumbnail_path)))
-                else:
-                    # Показать placeholder если миниатюра не создана
-                    item.setIcon(self._get_recorded_video_icon())
-                break
 
     def _get_recorded_video_icon(self) -> QIcon:
-        """
-        Получить placeholder иконку для записи без миниатюры.
-
-        Returns:
-            QIcon с placeholder (видеокамера или аналогичная иконка).
-        """
-        # Создать placeholder иконку (простой квадрат с текстом "VID")
-        # Используем стандартный icon для файлов видео
-        from PyQt6.QtWidgets import QStyle
-
-        style = self.style()
-        if style is not None:
-            return style.standardIcon(QStyle.StandardPixmap.SP_FileIcon)
-        return QIcon()
+        """Получить placeholder иконку для записи без миниатюры."""
+        return self._recordings_controller.get_recorded_video_icon()
 
     def _on_recording_paused(self) -> None:
         """Обработка приостановки записи."""
@@ -2233,7 +2014,7 @@ class MainWindow(QMainWindow):
         """Открытие файла записи."""
         path = item.data(Qt.ItemDataRole.UserRole)
         if path:
-            self._open_file(path)
+            self._open_file(str(path))
 
     def _open_selected_recording(self) -> None:
         """Открытие выбранного файла записи."""
@@ -2361,18 +2142,11 @@ class MainWindow(QMainWindow):
 
     def _check_dependencies(self) -> None:
         """Проверка необходимых зависимостей."""
-        threading.Thread(
-            target=self._check_dependencies_worker,
-            daemon=True,
-        ).start()
-
-    def _check_dependencies_worker(self) -> None:
-        """Выполнить проверку зависимостей в фоне."""
-        try:
-            result = check_ffmpeg()
-            self.dependency_check_completed.emit(result, None)
-        except Exception as error:
-            self.dependency_check_completed.emit(None, str(error))
+        self._readiness_controller.check_dependencies(
+            lambda result, error: self.dependency_check_completed.emit(
+                result, error
+            )
+        )
 
     def _on_dependency_check_completed(
         self,
@@ -2596,16 +2370,24 @@ class MainWindow(QMainWindow):
         output_path: Path,
     ) -> ReadinessSnapshot | None:
         """Вернуть последний readiness snapshot, если он ещё актуален."""
-        latest_inputs = self._latest_readiness_inputs
-        if latest_inputs is None or self._latest_readiness_snapshot is None:
+        if hasattr(self, "_readiness_controller"):
+            cached = self._readiness_controller.resolve_cached_snapshot(
+                capture, audio, output_path
+            )
+            if cached is not None:
+                return cached
+        latest_inputs = getattr(self, "_latest_readiness_inputs", None)
+        latest_snapshot = getattr(self, "_latest_readiness_snapshot", None)
+        if latest_inputs is None or latest_snapshot is None:
             return None
-
         if (
-            latest_inputs.get("capture") == capture
+            isinstance(latest_inputs, dict)
+            and latest_inputs.get("capture") == capture
             and latest_inputs.get("audio") == audio
             and latest_inputs.get("output_path") == output_path
+            and isinstance(latest_snapshot, ReadinessSnapshot)
         ):
-            return self._latest_readiness_snapshot
+            return latest_snapshot
         return None
 
     def _on_diagnostics_fix(self, check_name: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,12 +282,20 @@ class MockQWidgetBase:
         """Для QScrollArea."""
         return getattr(self, "_widget", None)
 
-    def addItem(self, item: str):
-        """Для QComboBox."""
+    def blockSignals(self, block: bool) -> bool:
+        """Для QWidget."""
+        prev = getattr(self, "_signals_blocked", False)
+        self._signals_blocked = block
+        return prev
 
+    def addItem(self, item: str, userData: Any = None):
+        """Для QComboBox."""
         if not hasattr(self, "_items"):
             self._items = []
+        if not hasattr(self, "_item_data"):
+            self._item_data = []
         self._items.append(item)
+        self._item_data.append(userData)
 
     def addItems(self, items: list):
         """Для QComboBox."""
@@ -541,6 +549,7 @@ class MockQListWidgetItem:
 
     def __init__(self, text: str = "", parent: Any = None):
         self._text = text
+        self._icon: Any = None
         self._data: dict[int, Any] = {}
         if parent is not None and hasattr(parent, "addItem"):
             parent.addItem(self)
@@ -550,6 +559,12 @@ class MockQListWidgetItem:
 
     def setText(self, text: str):
         self._text = text
+
+    def setIcon(self, icon: Any):
+        self._icon = icon
+
+    def icon(self) -> Any:
+        return self._icon
 
     def setData(self, role: int, value: Any):
         self._data[role] = value

--- a/tests/unit/gui/test_desktop_actions_controller.py
+++ b/tests/unit/gui/test_desktop_actions_controller.py
@@ -1,0 +1,52 @@
+"""
+Unit-тесты для DesktopActionsController
+======================================
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from PyQt6.QtWidgets import QPushButton, QWidget
+
+from gui.controllers.desktop_actions_controller import DesktopActionsController
+from gui.desktop_actions import DesktopActionId
+
+
+class TestDesktopActionsController:
+    """Тесты контроллера desktop-действий и доступности."""
+
+    def test_register_default_actions(self) -> None:
+        ctrl = DesktopActionsController()
+        cb = MagicMock()
+        callbacks = {
+            DesktopActionId.START_RECORDING: cb,
+            DesktopActionId.TOGGLE_PAUSE: cb,
+            DesktopActionId.STOP_RECORDING: cb,
+        }
+
+        ctrl.register_default_actions(callbacks)
+
+        assert ctrl.registry.get(DesktopActionId.START_RECORDING) is not None
+        assert ctrl.registry.get(DesktopActionId.TOGGLE_PAUSE) is not None
+        assert ctrl.registry.get(DesktopActionId.STOP_RECORDING) is not None
+
+    def test_apply_action_metadata(self) -> None:
+        ctrl = DesktopActionsController()
+        cb = MagicMock()
+        ctrl.register_default_actions({DesktopActionId.START_RECORDING: cb})
+
+        btn = QPushButton()
+        ctrl.apply_action_metadata(btn, DesktopActionId.START_RECORDING)
+
+        assert getattr(btn, "_accessible_name", None) is not None
+        assert getattr(btn, "_tooltip", None) is not None
+
+    def test_configure_tab_order(self) -> None:
+        ctrl = DesktopActionsController()
+        parent = QWidget()
+        b1 = QPushButton(parent)
+        b2 = QPushButton(parent)
+
+        ctrl.configure_tab_order(parent, [b1, b2])
+        assert ctrl.tab_navigation_order == [b1, b2]

--- a/tests/unit/gui/test_main_window.py
+++ b/tests/unit/gui/test_main_window.py
@@ -123,7 +123,38 @@ def _build_window():
     from gui.main_window import _ThreadTracker
 
     window._thread_tracker = _ThreadTracker()
+    from gui.controllers.desktop_actions_controller import (
+        DesktopActionsController,
+    )
+    from gui.controllers.profile_gui_controller import ProfileGUIController
+    from gui.controllers.readiness_controller import ReadinessController
+    from gui.controllers.recordings_controller import RecordingsController
     from gui.controllers.status_bar_controller import StatusBarController
+    from gui.desktop_actions import DesktopActionRegistry
+
+    window._desktop_actions = DesktopActionRegistry()
+    window._desktop_actions_controller = DesktopActionsController(
+        window._desktop_actions
+    )
+    window._registered_shortcuts = (
+        window._desktop_actions_controller.registered_shortcuts
+    )
+    window._tab_navigation_order = (
+        window._desktop_actions_controller.tab_navigation_order
+    )
+    window._readiness_controller = ReadinessController(
+        window._readiness_service,
+        track_thread=lambda t: None,
+    )
+    window._profile_gui_controller = ProfileGUIController()
+    window._recordings_controller = RecordingsController(
+        state=window._state,
+        settings_controller=window._settings_controller,
+        recordings_list=window.recordings_list,
+        filter_input=window._recordings_filter_input,
+        status_bar=window.status_bar,
+        track_thread=lambda t: None,
+    )
 
     window._status_bar_controller = StatusBarController(
         start_btn=window.start_btn,

--- a/tests/unit/gui/test_profile_gui_controller.py
+++ b/tests/unit/gui/test_profile_gui_controller.py
@@ -1,0 +1,99 @@
+"""
+Unit-тесты для ProfileGUIController
+==================================
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtWidgets import QComboBox, QStatusBar
+
+from core.recording_types import AudioMode, CaptureMode
+from gui.controllers.profile_gui_controller import ProfileGUIController
+from gui.models.recording_state import RecordingState
+from gui.views.audio_view import AudioView
+from gui.views.capture_view import CaptureView
+from gui.views.video_view import VideoView
+
+
+class TestProfileGUIController:
+    """Тесты контроллера интерфейса профилей."""
+
+    def test_init_profiles(self) -> None:
+        ctrl = ProfileGUIController()
+        combo = QComboBox()
+
+        mock_profile = MagicMock()
+        mock_profile.id = "p1"
+        mock_profile.name = "Test Profile"
+        mock_profile.icon = "🎬"
+        mock_profile.is_default = True
+
+        with patch(
+            "gui.controllers.profile_gui_controller.get_profile_storage"
+        ) as mock_storage:
+            mock_storage.return_value.list_profiles.return_value = [
+                mock_profile
+            ]
+            ctrl.init_profiles(combo)
+
+        assert combo.count() == 1
+        assert "Test Profile" in combo.itemText(0)
+        assert combo.itemData(0) == "p1"
+
+    def test_on_profile_combo_changed(self) -> None:
+        ctrl = ProfileGUIController()
+        combo = QComboBox()
+        combo.addItem("Profile 1", "p1")
+
+        mock_profile = MagicMock()
+        mock_profile.id = "p1"
+        apply_cb = MagicMock()
+
+        with patch(
+            "gui.controllers.profile_gui_controller.get_profile_storage"
+        ) as mock_storage:
+            mock_storage.return_value.get_profile.return_value = mock_profile
+            ctrl.on_profile_combo_changed(0, combo, apply_cb)
+
+        apply_cb.assert_called_once_with(mock_profile)
+
+    def test_apply_profile_settings(self) -> None:
+        ctrl = ProfileGUIController()
+
+        mock_profile = MagicMock()
+        mock_profile.id = "p1"
+        mock_profile.name = "My Profile"
+        mock_profile.video.fps = 60
+        mock_profile.video.codec = "h264"
+        mock_profile.video.bitrate = "5M"
+        mock_profile.video.format = "mp4"
+        mock_profile.video.preset = "fast"
+        mock_profile.audio.record_mic = True
+        mock_profile.audio.record_system = False
+        mock_profile.capture.area_type = "full"
+        mock_profile.capture.window_title = ""
+        mock_profile.capture.rect_coords = None
+
+        video_view = MagicMock(spec=VideoView)
+        audio_view = MagicMock(spec=AudioView)
+        capture_view = MagicMock(spec=CaptureView)
+        state = RecordingState()
+        combo = QComboBox()
+        combo.addItem("My Profile", "p1")
+        status_bar = QStatusBar()
+
+        ctrl.apply_profile_settings(
+            mock_profile,
+            video_view=video_view,
+            audio_view=audio_view,
+            capture_view=capture_view,
+            state=state,
+            combo=combo,
+            status_bar=status_bar,
+        )
+
+        video_view.set_fps.assert_called_once_with(60)
+        assert state.audio.audio_type == AudioMode.MIC
+        capture_view.set_capture_type.assert_called_once_with(CaptureMode.FULL)

--- a/tests/unit/gui/test_readiness_controller.py
+++ b/tests/unit/gui/test_readiness_controller.py
@@ -1,0 +1,91 @@
+"""
+Unit-тесты для ReadinessController
+=================================
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from core.readiness import ReadinessSnapshot
+from core.recording_types import AudioMode, CaptureMode
+from gui.controllers.readiness_controller import ReadinessController
+from gui.models.recording_state import AudioSettings, CaptureSettings
+from recorder.utils import FFmpegStatus
+
+
+class TestReadinessController:
+    """Тесты контроллера проверки готовности."""
+
+    def test_check_dependencies(self) -> None:
+        readiness_service = MagicMock()
+        ctrl = ReadinessController(readiness_service=readiness_service)
+
+        mock_status = FFmpegStatus(
+            available=True, version="6.0", path="ffmpeg.exe"
+        )
+        callback = MagicMock()
+
+        with patch(
+            "gui.controllers.readiness_controller.check_ffmpeg",
+            return_value=mock_status,
+        ):
+            ctrl.check_dependencies(callback)
+
+        callback.assert_called_once_with(mock_status, None)
+
+    def test_request_readiness_refresh(self, tmp_path: Path) -> None:
+        readiness_service = MagicMock()
+        mock_snapshot = ReadinessSnapshot(issues=())
+        readiness_service.evaluate.return_value = mock_snapshot
+
+        ctrl = ReadinessController(readiness_service=readiness_service)
+
+        capture = CaptureSettings(capture_type=CaptureMode.FULL)
+        audio = AudioSettings(audio_type=AudioMode.NONE)
+        output_path = tmp_path / "out.mp4"
+
+        callback = MagicMock()
+        req_id = ctrl.request_readiness_refresh(
+            capture=capture,
+            audio=audio,
+            output_path=output_path,
+            on_completed=callback,
+        )
+
+        assert req_id == 1
+        assert ctrl.is_request_current(1)
+        callback.assert_called_once_with(
+            1, mock_snapshot, None, capture, audio
+        )
+
+    def test_store_and_resolve_cached_snapshot(self, tmp_path: Path) -> None:
+        readiness_service = MagicMock()
+        ctrl = ReadinessController(readiness_service=readiness_service)
+
+        capture = CaptureSettings(capture_type=CaptureMode.FULL)
+        audio = AudioSettings(audio_type=AudioMode.NONE)
+        output_path = tmp_path / "out.mp4"
+
+        mock_snapshot = ReadinessSnapshot(issues=())
+
+        ctrl.store_readiness_result(mock_snapshot, capture, audio, output_path)
+
+        # Совпадающие параметры возвращают кэш
+        cached = ctrl.resolve_cached_snapshot(capture, audio, output_path)
+        assert cached is mock_snapshot
+
+        # Другие параметры возвращают None
+        other_path = tmp_path / "other.mp4"
+        assert ctrl.resolve_cached_snapshot(capture, audio, other_path) is None
+
+    def test_handle_readiness_action(self) -> None:
+        readiness_service = MagicMock()
+        ctrl = ReadinessController(readiness_service=readiness_service)
+
+        mock_handler = MagicMock()
+        handlers = {"choose_output_path": mock_handler}
+
+        ctrl.handle_readiness_action("Папка вывода", handlers)
+        mock_handler.assert_called_once()

--- a/tests/unit/gui/test_recordings_controller.py
+++ b/tests/unit/gui/test_recordings_controller.py
@@ -1,0 +1,148 @@
+"""
+Unit-тесты для RecordingsController
+==================================
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtWidgets import (
+    QLineEdit,
+    QListWidget,
+    QStatusBar,
+)
+
+from gui.controllers.recordings_controller import RecordingsController
+from gui.controllers.settings_controller import SettingsController
+from gui.models.recording_state import RecentRecording, RecordingState
+
+
+class TestRecordingsController:
+    """Тесты контроллера недавних записей."""
+
+    def test_filter_matching(self) -> None:
+        assert RecordingsController.recording_matches_filter(
+            "my_video.mp4", "2026-08-18", "video"
+        )
+        assert RecordingsController.recording_matches_filter(
+            "my_video.mp4", "2026-08-18", "2026"
+        )
+        assert not RecordingsController.recording_matches_filter(
+            "my_video.mp4", "2026-08-18", "xyz"
+        )
+        assert RecordingsController.recording_matches_filter(
+            "my_video.mp4", "2026-08-18", ""
+        )
+
+    def test_refresh_recent_recordings(self, tmp_path: Path) -> None:
+        rec_file = tmp_path / "rec1.mp4"
+        rec_file.write_text("dummy")
+
+        state = RecordingState()
+        state.recent_recordings = [
+            RecentRecording(path=rec_file, size=5, date="2026-08-18 10:00")
+        ]
+        settings_ctrl = MagicMock(spec=SettingsController)
+        list_widget = QListWidget()
+        filter_input = QLineEdit()
+
+        ctrl = RecordingsController(
+            state=state,
+            settings_controller=settings_ctrl,
+            recordings_list=list_widget,
+            filter_input=filter_input,
+        )
+
+        with patch(
+            "gui.controllers.recordings_controller.generate_thumbnail",
+            return_value=None,
+        ):
+            ctrl.refresh_recent_recordings()
+
+        assert list_widget.count() == 1
+        item = list_widget.item(0)
+        assert item is not None
+        assert "rec1.mp4" in item.text()
+
+    def test_clear_filter(self) -> None:
+        state = RecordingState()
+        settings_ctrl = MagicMock(spec=SettingsController)
+        list_widget = QListWidget()
+        filter_input = QLineEdit()
+        filter_input.setText("filter text")
+
+        ctrl = RecordingsController(
+            state=state,
+            settings_controller=settings_ctrl,
+            recordings_list=list_widget,
+            filter_input=filter_input,
+        )
+        ctrl.clear_recordings_filter()
+        assert filter_input.text() == ""
+
+    def test_clear_recent_recordings(self) -> None:
+        state = RecordingState()
+        settings_ctrl = MagicMock(spec=SettingsController)
+        list_widget = QListWidget()
+        filter_input = QLineEdit()
+        status_bar = QStatusBar()
+
+        ctrl = RecordingsController(
+            state=state,
+            settings_controller=settings_ctrl,
+            recordings_list=list_widget,
+            filter_input=filter_input,
+            status_bar=status_bar,
+        )
+        ctrl.clear_recent_recordings()
+        settings_ctrl.clear_recent_recordings.assert_called_once()
+
+    def test_open_file_and_folder(self) -> None:
+        state = RecordingState()
+        settings_ctrl = MagicMock(spec=SettingsController)
+        list_widget = QListWidget()
+        filter_input = QLineEdit()
+
+        ctrl = RecordingsController(
+            state=state,
+            settings_controller=settings_ctrl,
+            recordings_list=list_widget,
+            filter_input=filter_input,
+        )
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("os.startfile") as mock_startfile,
+        ):
+            ctrl.open_file("C:/test/file.mp4")
+            mock_startfile.assert_called_once_with("C:/test/file.mp4")
+
+        with (
+            patch("platform.system", return_value="Windows"),
+            patch("subprocess.run") as mock_run,
+        ):
+            ctrl.open_folder("C:/test")
+            mock_run.assert_called_once_with(["explorer", "C:/test"])
+
+    def test_open_application_logs(self) -> None:
+        state = RecordingState()
+        settings_ctrl = MagicMock(spec=SettingsController)
+        list_widget = QListWidget()
+        filter_input = QLineEdit()
+        status_bar = QStatusBar()
+
+        ctrl = RecordingsController(
+            state=state,
+            settings_controller=settings_ctrl,
+            recordings_list=list_widget,
+            filter_input=filter_input,
+            status_bar=status_bar,
+        )
+
+        with patch(
+            "gui.controllers.recordings_controller.open_logs_folder"
+        ) as mock_logs:
+            ctrl.open_application_logs()
+            mock_logs.assert_called_once()


### PR DESCRIPTION
Closes #115

### Описание изменений
- Выделены 4 модульных контроллера в gui/controllers/:
  - RecordingsController — инкапсулирует операции со списком записей, фильтрацию, генерацию и обновление миниатюр, открытие файлов/папок и логов, контекстное меню.
  - ReadinessController — инкапсулирует оценку готовности к записи, фоновую проверку FFmpeg зависимостей, кэширование снимков готовности и диспетчеризацию быстрых действий.
  - DesktopActionsController — инкапсулирует регистрацию системных desktop-действий, назначение tooltip/accessibility metadata, настройку порядка табуляции и регистрацию QShortcut.
  - ProfileGUIController — инкапсулирует управление выпадающим списком профилей, открытие диалога профилей и применение настроек профиля (видео, аудио, область захвата) к представлениям и модели.
- В MainWindow методы делегируют вызовы соответствующим контроллерам с сохранением полной обратной совместимости.
- Добавлены подробные unit-тесты для каждого из новых контроллеров.